### PR TITLE
Add support for `json.Number` to `dataconv.Marshal`

### DIFF
--- a/dataconv/marshal.go
+++ b/dataconv/marshal.go
@@ -3,6 +3,7 @@ package dataconv
 // Based on https://github.com/qri-io/starlib/tree/master/util with some modifications and additions
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -22,6 +23,8 @@ func Marshal(data interface{}) (v starlark.Value, err error) {
 	case bool:
 		v = starlark.Bool(x)
 	case string:
+		v = starlark.String(x)
+	case json.Number:
 		v = starlark.String(x)
 	case int:
 		v = starlark.MakeInt(x)

--- a/dataconv/marshal_test.go
+++ b/dataconv/marshal_test.go
@@ -68,6 +68,7 @@ func TestMarshal(t *testing.T) {
 		{nil, starlark.None, ""},
 		{true, starlark.True, ""},
 		{"foo", starlark.String("foo"), ""},
+		{json.Number("42"), starlark.String("42"), ""},
 		{42, starlark.MakeInt(42), ""},
 		{int8(42), starlark.MakeInt(42), ""},
 		{int16(42), starlark.MakeInt(42), ""},


### PR DESCRIPTION
### What

Adds a case to the `dataconv.Marshal` type switch that retains values passed as `json.Number` as their underlying string value.

### Why

In instances where a user is consuming raw JSON without a predetermined struct for unmarshaling, they often unmarshal into a `map[string]interface{}`. When doing this all numbers are converted to floats, even if they have no fractional part. Eg:

```go
var v map[string]any
json.Unmarshal([]byte(`{"value":6}`), &v)
fmt.Printf("%T", v["value"])
// float64
```

Therefore a user, in a situation where they are unmarshaling deeply-nested JSON into a `map[string]interface{}` and then marshaling using `dataconv.Marshal` for use in Starlark, can expect integers to be misidentified as floats. Checks inside the script will fail to distinguish between integers and floats.

To simplify this situation, we ask the Go JSON decoder to use `json.Number` values for all numerics.

```go
var v map[string]any
dec := json.NewDecoder(bytes.NewReader([]byte(`{"value":6}`)))
dec.UseNumber()
dec.Decode(&v)
fmt.Printf("%T", v["value"])
// json.Number
```

If `dataconv.Marshal` converts the value to a string representation, then we can handle the values differently based on `str.isdigit()` and `str.isdecimal()` within the script.