### PR TITLE
[test] LET-23: hermetic default test suite, real-network cases behind an integration tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ build:
 test:
 	$(GOTEST) -v -race -cover -covermode=atomic -count 1 ./...
 
+# real-network smoke tests, excluded from the default (hermetic) suite
+test_integration:
+	$(GOTEST) -v -race -tags integration -count 1 ./lib/net/...
+
 test_loop:
 	while true; do \
 		$(GOTEST) -v -race -cover -covermode=atomic -count 1 ./...; \

--- a/lib/file/file_test.go
+++ b/lib/file/file_test.go
@@ -20,6 +20,7 @@ func TestLoadModule_File(t *testing.T) {
 		wantErr     string
 		fileContent string
 		skipWindows bool
+		skipRoot    bool
 	}{
 		{
 			name: `trim bom`,
@@ -965,12 +966,12 @@ func TestLoadModule_File(t *testing.T) {
 			name: `stat: no perm`,
 			script: itn.HereDoc(`
 				load('file', 'stat')
-				fp = '/etc/sudoers'
-				s = stat(fp)
+				s = stat(no_perm_file)
 				s.get_md5()
 			`),
-			wantErr:     `get_md5: open /etc/sudoers`,
+			wantErr:     `permission denied`,
 			skipWindows: true,
+			skipRoot:    true, // root ignores file permission bits
 		},
 	}
 	for _, tt := range tests {
@@ -978,6 +979,10 @@ func TestLoadModule_File(t *testing.T) {
 			// skip windows
 			if isOnWindows && tt.skipWindows {
 				t.Skipf("Skip test on Windows")
+				return
+			}
+			if tt.skipRoot && os.Geteuid() == 0 {
+				t.Skipf("Skip test as root")
 				return
 			}
 
@@ -1007,6 +1012,25 @@ func TestLoadModule_File(t *testing.T) {
 					"temp_file": starlark.String(tp),
 					"temp_dir":  starlark.String(td),
 				}
+			}
+
+			// a hermetic permission barrier: an unreadable temp file (instead
+			// of relying on environment-specific paths like /etc/sudoers)
+			if strings.Contains(tt.script, "no_perm_file") {
+				npf, err := os.CreateTemp("", "starlet-file-test-noperm")
+				if err != nil {
+					t.Errorf("os.CreateTemp() expects no error, actual error = '%v'", err)
+					return
+				}
+				_ = npf.Close()
+				if err := os.Chmod(npf.Name(), 0o000); err != nil {
+					t.Errorf("os.Chmod() expects no error, actual error = '%v'", err)
+					return
+				}
+				if predecl == nil {
+					predecl = starlark.StringDict{}
+				}
+				predecl["no_perm_file"] = starlark.String(npf.Name())
 			}
 
 			// execute test

--- a/lib/net/integration_test.go
+++ b/lib/net/integration_test.go
@@ -1,0 +1,83 @@
+//go:build integration
+
+// Real-network smoke tests for lib/net, excluded from the default (hermetic)
+// suite. They exercise the paths a local stub cannot reach: the system
+// resolver, the default-DNS-port append branch, and real TCP/HTTPS targets.
+//
+// Run with: make test_integration
+//
+//	or: go test -tags integration ./lib/net/...
+package net_test
+
+import (
+	"testing"
+
+	itn "github.com/1set/starlet/internal"
+	"github.com/1set/starlet/lib/net"
+)
+
+func TestIntegration_RealNetwork(t *testing.T) {
+	tests := []struct {
+		name    string
+		script  string
+		wantErr string
+	}{
+		{
+			name: `nslookup: system resolver`,
+			script: itn.HereDoc(`
+				load('net', 'nslookup')
+				ips = nslookup('bing.com')
+				print(ips)
+				assert.true(len(ips) > 0)
+			`),
+		},
+		{
+			name: `nslookup: custom dns without port`, // covers the default-:53 append branch
+			script: itn.HereDoc(`
+				load('net', 'nslookup')
+				ips = nslookup('bing.com', '8.8.8.8')
+				print(ips)
+				assert.true(len(ips) > 0)
+			`),
+		},
+		{
+			name: `nslookup: custom dns with port`,
+			script: itn.HereDoc(`
+				load('net', 'nslookup')
+				ips = nslookup('bing.com', '1.1.1.1:53')
+				print(ips)
+				assert.true(len(ips) > 0)
+			`),
+		},
+		{
+			name: `tcping: real host`,
+			script: itn.HereDoc(`
+				load('net', 'tcping')
+				s = tcping('bing.com', count=2, interval=0.1)
+				print(s)
+				assert.eq(s.total, 2)
+				assert.true(s.success > 0)
+			`),
+		},
+		{
+			name: `httping: real host`,
+			script: itn.HereDoc(`
+				load('net', 'httping')
+				s = httping('https://www.bing.com', count=2, interval=0.1)
+				print(s)
+				assert.eq(s.total, 2)
+				assert.true(s.success > 0)
+				assert.true(s.min > 0)
+			`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := itn.ExecModuleWithErrorTest(t, net.ModuleName, net.LoadModule, tt.script, tt.wantErr, nil)
+			if (err != nil) != (tt.wantErr != "") {
+				t.Errorf("net(%q) expects error = '%v', actual error = '%v', result = %v", tt.name, tt.wantErr, err, res)
+				return
+			}
+		})
+	}
+}

--- a/lib/net/network_test.go
+++ b/lib/net/network_test.go
@@ -1,14 +1,79 @@
 package net_test
 
 import (
+	stdnet "net"
 	"runtime"
 	"testing"
 
 	itn "github.com/1set/starlet/internal"
 	"github.com/1set/starlet/lib/net"
+	"go.starlark.net/starlark"
 )
 
+// startDNSStub runs a minimal UDP DNS server on 127.0.0.1 and returns its
+// host:port. It answers every A question with 127.0.0.1 and any other
+// question with an empty NOERROR response. With blackhole=true it reads
+// queries and never replies, so clients hit a deterministic timeout.
+//
+// NOTE: a custom dns_server only takes effect where the pure-Go resolver
+// honours a custom Dial — on Windows PreferGo is a no-op before Go 1.19
+// (the system resolver is used instead), so stub-based cases must skip
+// Windows while the module floor is go 1.18.
+func startDNSStub(t *testing.T, blackhole bool) string {
+	t.Helper()
+	pc, err := stdnet.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start DNS stub: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+	go func() {
+		buf := make([]byte, 512)
+		for {
+			n, addr, err := pc.ReadFrom(buf)
+			if err != nil {
+				return // listener closed
+			}
+			if blackhole || n < 12 {
+				continue
+			}
+			q := buf[:n]
+			// skip the QNAME labels of the first question
+			i := 12
+			for i < len(q) && q[i] != 0 {
+				i += int(q[i]) + 1
+			}
+			qend := i + 5 // NUL + QTYPE(2) + QCLASS(2)
+			if qend > len(q) {
+				continue
+			}
+			isA := q[i+1] == 0 && q[i+2] == 1
+			ancount := byte(0)
+			if isA {
+				ancount = 1
+			}
+			resp := make([]byte, 0, qend+16)
+			resp = append(resp, q[0], q[1], 0x81, 0x80)       // ID, QR|RD|RA, NOERROR
+			resp = append(resp, 0, 1, 0, ancount, 0, 0, 0, 0) // QD=1, AN, NS=0, AR=0
+			resp = append(resp, q[12:qend]...)                // echo the question
+			if isA {
+				resp = append(resp,
+					0xC0, 0x0C, // NAME: pointer to the question name
+					0, 1, 0, 1, // TYPE A, CLASS IN
+					0, 0, 0, 60, // TTL 60s
+					0, 4, 127, 0, 0, 1, // RDLENGTH 4, RDATA 127.0.0.1
+				)
+			}
+			_, _ = pc.WriteTo(resp, addr)
+		}
+	}()
+	return pc.LocalAddr().String()
+}
+
 func TestLoadModule_NSLookUp(t *testing.T) {
+	// hermetic local DNS servers: one answering, one swallowing queries
+	dnsStub := startDNSStub(t, false)
+	dnsBlackhole := startDNSStub(t, true)
+
 	isOnWindows := runtime.GOOS == "windows"
 	tests := []struct {
 		name        string
@@ -20,37 +85,22 @@ func TestLoadModule_NSLookUp(t *testing.T) {
 			name: `nslookup: normal`,
 			script: itn.HereDoc(`
 				load('net', 'nslookup')
-				ips = nslookup('bing.com')
+				ips = nslookup('hermetic.test', dns_stub)
 				print(ips)
 				assert.true(len(ips) > 0)
+				assert.true('127.0.0.1' in ips)
 			`),
+			skipWindows: true, // PreferGo resolver is a no-op on Windows before Go 1.19
 		},
 		{
 			name: `nslookup: normal with timeout`,
 			script: itn.HereDoc(`
 				load('net', 'nslookup')
-				ips = nslookup('bing.com', timeout=5)
+				ips = nslookup('hermetic.test', dns_stub, timeout=5)
 				print(ips)
 				assert.true(len(ips) > 0)
 			`),
-		},
-		{
-			name: `nslookup: normal with dns`,
-			script: itn.HereDoc(`
-				load('net', 'nslookup')
-				ips = nslookup('bing.com', '8.8.8.8')
-				print(ips)
-				assert.true(len(ips) > 0)
-			`),
-		},
-		{
-			name: `nslookup: normal with dns:port`,
-			script: itn.HereDoc(`
-				load('net', 'nslookup')
-				ips = nslookup('bing.com', '1.1.1.1:53')
-				print(ips)
-				assert.true(len(ips) > 0)
-			`),
+			skipWindows: true, // PreferGo resolver is a no-op on Windows before Go 1.19
 		},
 		{
 			name: `nslookup: ip`,
@@ -76,16 +126,16 @@ func TestLoadModule_NSLookUp(t *testing.T) {
 				load('net', 'nslookup')
 				ips = nslookup('missing.invalid')
 			`),
-			wantErr: `missing.invalid`, // mac/win: no such host, linux: server misbehaving
+			wantErr: `missing.invalid`, // the error always names the domain, online (NXDOMAIN) or offline
 		},
 		{
 			name: `nslookup: wrong dns`,
 			script: itn.HereDoc(`
 				load('net', 'nslookup')
-				ips = nslookup('bing.com', 'microsoft.com', timeout=1)
+				ips = nslookup('hermetic.test', dns_blackhole, timeout=1)
 			`),
-			wantErr:     `timeout`, // Accept any error containing "timeout"
-			skipWindows: true,      // on Windows 2022 with Go 1.18.10, it returns results from the default DNS server
+			wantErr:     `timeout`,
+			skipWindows: true, // PreferGo resolver is a no-op on Windows before Go 1.19
 		},
 		{
 			name: `nslookup: no args`,
@@ -110,7 +160,11 @@ func TestLoadModule_NSLookUp(t *testing.T) {
 				t.Skipf("Skip test on Windows")
 				return
 			}
-			res, err := itn.ExecModuleWithErrorTest(t, net.ModuleName, net.LoadModule, tt.script, tt.wantErr, nil)
+			extra := starlark.StringDict{
+				"dns_stub":      starlark.String(dnsStub),
+				"dns_blackhole": starlark.String(dnsBlackhole),
+			}
+			res, err := itn.ExecModuleWithErrorTest(t, net.ModuleName, net.LoadModule, tt.script, tt.wantErr, extra)
 			if (err != nil) != (tt.wantErr != "") {
 				t.Errorf("net(%q) expects error = '%v', actual error = '%v', result = %v", tt.name, tt.wantErr, err, res)
 				return

--- a/lib/net/ping_test.go
+++ b/lib/net/ping_test.go
@@ -1,6 +1,7 @@
 package net_test
 
 import (
+	stdnet "net"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -28,14 +29,54 @@ func createRedirectMockServer(location string) *httptest.Server {
 	return httptest.NewServer(handler)
 }
 
+// startLocalTCPServer listens on the loopback interface and accepts-then-closes
+// connections, giving tcping a hermetic target.
+func startLocalTCPServer(t *testing.T) (port int) {
+	t.Helper()
+	ln, err := stdnet.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start local TCP server: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return // listener closed
+			}
+			_ = conn.Close()
+		}
+	}()
+	return ln.Addr().(*stdnet.TCPAddr).Port
+}
+
+// closedTCPPort returns a loopback port that was just released, so dialing it
+// fails immediately with a connection error.
+func closedTCPPort(t *testing.T) (port int) {
+	t.Helper()
+	ln, err := stdnet.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to probe for a closed port: %v", err)
+	}
+	port = ln.Addr().(*stdnet.TCPAddr).Port
+	_ = ln.Close()
+	return port
+}
+
 func TestLoadModule_Ping(t *testing.T) {
 	// create mock servers for testing
+	serverOK := createMockServer(http.StatusOK)
+	defer serverOK.Close()
 	server301 := createRedirectMockServer("https://notgoingthere.invalid")
 	defer server301.Close()
 	server404 := createMockServer(http.StatusNotFound)
 	defer server404.Close()
 	server500 := createMockServer(http.StatusInternalServerError)
 	defer server500.Close()
+
+	// hermetic TCP targets: one accepting, one just released (closed)
+	tcpPort := startLocalTCPServer(t)
+	tcpPortClosed := closedTCPPort(t)
 
 	isOnWindows := runtime.GOOS == "windows"
 	tests := []struct {
@@ -44,12 +85,12 @@ func TestLoadModule_Ping(t *testing.T) {
 		wantErr     string
 		skipWindows bool
 	}{
-		// TCPing tests
+		// TCPing tests (IP-literal targets resolve without touching DNS)
 		{
 			name: `tcping: normal`,
 			script: itn.HereDoc(`
 				load('net', 'tcping')
-				s = tcping('bing.com')
+				s = tcping('127.0.0.1', port=tcp_port, interval=0.1)
 				print(s)
 				assert.eq(s.total, 4)
 				assert.true(s.success > 0)
@@ -59,7 +100,7 @@ func TestLoadModule_Ping(t *testing.T) {
 			name: `tcping: abnormal`,
 			script: itn.HereDoc(`
 				load('net', 'tcping')
-				s = tcping('bing.com', count=1, timeout=-5, interval=-2)
+				s = tcping('127.0.0.1', port=tcp_port, count=1, timeout=-5, interval=-2)
 				print(s)
 				assert.eq(s.total, 1)
 				assert.true(s.success > 0)
@@ -70,11 +111,19 @@ func TestLoadModule_Ping(t *testing.T) {
 			name: `tcping: faster`,
 			script: itn.HereDoc(`
 				load('net', 'tcping')
-				s = tcping('bing.com', count=10, timeout=5, interval=0.01)
+				s = tcping('127.0.0.1', port=tcp_port, count=10, timeout=5, interval=0.01)
 				print(s)
 				assert.eq(s.total, 10)
 				assert.true(s.success > 0)
 			`),
+		},
+		{
+			name: `tcping: closed port`,
+			script: itn.HereDoc(`
+				load('net', 'tcping')
+				s = tcping('127.0.0.1', port=tcp_port_closed, count=2, timeout=2, interval=0.01)
+			`),
+			wantErr: `net.tcping: no successful connections`,
 		},
 		{
 			name: `tcping: not exists`,
@@ -82,13 +131,13 @@ func TestLoadModule_Ping(t *testing.T) {
 				load('net', 'tcping')
 				s = tcping('missing.invalid')
 			`),
-			wantErr: `missing.invalid`, // mac/win: no such host, linux: server misbehaving
+			wantErr: `missing.invalid`, // the error always names the host, online (NXDOMAIN) or offline
 		},
 		{
 			name: `tcping: wrong count`,
 			script: itn.HereDoc(`
 				load('net', 'tcping')
-				s = tcping('bing.com', count=0)
+				s = tcping('127.0.0.1', count=0)
 			`),
 			wantErr: `net.tcping: count must be greater than 0`,
 		},
@@ -109,12 +158,12 @@ func TestLoadModule_Ping(t *testing.T) {
 			wantErr: `net.tcping: for parameter hostname: got int, want string or bytes`,
 		},
 
-		// HTTPing tests
+		// HTTPing tests (loopback httptest targets)
 		{
 			name: `httping: normal`,
 			script: itn.HereDoc(`
 				load('net', 'httping')
-				s = httping('https://www.bing.com')
+				s = httping(server_ok, interval=0.1)
 				print(s)
 				assert.eq(s.total, 4)
 				assert.true(s.success > 0)
@@ -125,7 +174,7 @@ func TestLoadModule_Ping(t *testing.T) {
 			name: `httping: abnormal`,
 			script: itn.HereDoc(`
 				load('net', 'httping')
-				s = httping('https://www.bing.com', count=1, timeout=-5, interval=-2)
+				s = httping(server_ok, count=1, timeout=-5, interval=-2)
 				print(s)
 				assert.eq(s.total, 1)
 				assert.true(s.success > 0)
@@ -136,7 +185,7 @@ func TestLoadModule_Ping(t *testing.T) {
 			name: `httping: faster`,
 			script: itn.HereDoc(`
 				load('net', 'httping')
-				s = httping('https://www.bing.com', count=10, timeout=5, interval=0.01)
+				s = httping(server_ok, count=10, timeout=5, interval=0.01)
 				print(s)
 				assert.eq(s.total, 10)
 				assert.true(s.success > 0)
@@ -174,13 +223,13 @@ func TestLoadModule_Ping(t *testing.T) {
 				load('net', 'httping')
 				s = httping('http://missing.invalid')
 			`),
-			wantErr: `net.httping: no successful connections`, // mac/win: no such host, linux: server misbehaving
+			wantErr: `net.httping: no successful connections`,
 		},
 		{
 			name: `httping: wrong count`,
 			script: itn.HereDoc(`
 				load('net', 'httping')
-				s = httping('https://www.bing.com', count=0)
+				s = httping(server_ok, count=0)
 			`),
 			wantErr: `net.httping: count must be greater than 0`,
 		},
@@ -208,9 +257,12 @@ func TestLoadModule_Ping(t *testing.T) {
 				return
 			}
 			extra := starlark.StringDict{
-				"server_301": starlark.String(server301.URL),
-				"server_404": starlark.String(server404.URL),
-				"server_500": starlark.String(server500.URL),
+				"server_ok":       starlark.String(serverOK.URL),
+				"server_301":      starlark.String(server301.URL),
+				"server_404":      starlark.String(server404.URL),
+				"server_500":      starlark.String(server500.URL),
+				"tcp_port":        starlark.MakeInt(tcpPort),
+				"tcp_port_closed": starlark.MakeInt(tcpPortClosed),
 			}
 			res, err := itn.ExecModuleWithErrorTest(t, net.ModuleName, net.LoadModule, tt.script, tt.wantErr, extra)
 			if (err != nil) != (tt.wantErr != "") {

--- a/lib/net/ping_test.go
+++ b/lib/net/ping_test.go
@@ -167,7 +167,8 @@ func TestLoadModule_Ping(t *testing.T) {
 				print(s)
 				assert.eq(s.total, 4)
 				assert.true(s.success > 0)
-				assert.true(s.min > 0)
+				# loopback connects can finish within one Windows clock tick (~0.5ms)
+				assert.true(s.min >= 0)
 			`),
 		},
 		{
@@ -189,7 +190,8 @@ func TestLoadModule_Ping(t *testing.T) {
 				print(s)
 				assert.eq(s.total, 10)
 				assert.true(s.success > 0)
-				assert.true(s.min > 0)
+				# loopback connects can finish within one Windows clock tick (~0.5ms)
+				assert.true(s.min >= 0)
 			`),
 		},
 		{

--- a/lib/path/path_test.go
+++ b/lib/path/path_test.go
@@ -17,6 +17,7 @@ func TestLoadModule_Path(t *testing.T) {
 		script      string
 		wantErr     string
 		skipWindows bool
+		skipRoot    bool
 	}{
 		{
 			name: `join: no args`,
@@ -384,6 +385,7 @@ func TestLoadModule_Path(t *testing.T) {
 			`),
 			wantErr:     `path.listdir: open /`,
 			skipWindows: true,
+			skipRoot:    true, // root can read these directories, so the error never happens
 		},
 		{
 			name: `getcwd: no args`,
@@ -492,6 +494,22 @@ func TestLoadModule_Path(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.skipRoot && os.Geteuid() == 0 {
+				t.Skipf("Skip test as root")
+				return
+			}
+			// path.chdir mutates the process-global CWD; restore it after each
+			// case so cases stay independent and the suite survives -count=2.
+			origWD, err := os.Getwd()
+			if err != nil {
+				t.Fatalf("os.Getwd() expects no error, actual error = '%v'", err)
+			}
+			defer func() {
+				if err := os.Chdir(origWD); err != nil {
+					t.Fatalf("failed to restore working directory: %v", err)
+				}
+			}()
+
 			// prepare temp file if needed
 			var (
 				tp string


### PR DESCRIPTION
## Why

The default test suite was not runnable offline and was environment-sensitive (Backlog **LET-23**):

- `lib/net` tests dialed public endpoints directly: `bing.com`, `8.8.8.8`, and `1.1.1.1:53` — CI depended on third-party availability, and `go test ./...` failed in any sandboxed/offline environment.
- `lib/path`'s `chdir: parent path` case leaked the process CWD, so `go test -count=2 ./lib/path` failed deterministically on the second pass (and `-race -count=2` is this ecosystem's standard bar).
- `lib/path`/`lib/file` permission cases relied on environment-specific paths (`/root`, `/var/db/sudo`, `/etc/sudoers`) and failed in containers (path absent, or running as root).

## What

- **lib/net, hermetic by default**: a minimal in-test **UDP DNS stub** (answers A questions with `127.0.0.1`; a blackhole variant yields deterministic timeouts) wired through the existing `dns_server` parameter; a loopback TCP listener (plus a just-released closed port) for `tcping` via the existing `port` parameter; `httping` targets local `httptest` servers. Stub-based nslookup cases skip Windows: `Resolver.PreferGo` is a no-op there before Go 1.19, and the module floor is still go 1.18 (this also explains the old `wrong dns` skip).
- **Real-network smoke moves behind a build tag**: `lib/net/integration_test.go` (`//go:build integration`) keeps coverage of the system resolver, the default-`:53`-append branch, and real TCP/HTTPS targets. New `make test_integration` runs it.
- **lib/path**: save/restore the CWD around every case; skip the no-permission case as root.
- **lib/file**: the permission barrier is now an unreadable (chmod 000) temp file + root skip, instead of `/etc/sudoers`.

## Verification

- `go test -race -count=2 ./lib/net/ ./lib/path/` green (the `-count=2` leg used to fail).
- `go test -tags integration -race ./lib/net/` green against the real network.
- `docker run golang:1.18 go test ./...` **fully green for the first time** (previously failed on `lib/file` in containers).

Refs: LET-23

🤖 Generated with [Claude Code](https://claude.com/claude-code)