### PR TITLE
[fix] LET-06: substring no longer treats an explicit end of 0 as 'to the end'

### DIFF
--- a/lib/string/README.md
+++ b/lib/string/README.md
@@ -172,9 +172,9 @@ print(rfind(s, "x"))
 # Output: -1
 ```
 
-### `substring(s, start, end) string`
+### `substring(s, start, end=None) string`
 
-Returns a substring of `s` from index `start` to `end` (exclusive).
+Returns a substring of `s` from index `start` to `end` (exclusive). If `end` is omitted or `None`, the substring extends to the end of the string. An explicit `end` of `0` (or `-len(s)`) means an empty range, as in Python slicing; out-of-range indices are reported as errors.
 
 #### Parameters
 
@@ -182,7 +182,7 @@ Returns a substring of `s` from index `start` to `end` (exclusive).
 |---------|----------|--------------------------------------|
 | `s`     | `string` | The string to be sliced              |
 | `start` | `int`    | The starting index for the substring |
-| `end`   | `int`    | The ending index for the substring   |
+| `end`   | `int` or `None` | Optional ending index (exclusive); defaults to the end of the string |
 
 #### Examples
 

--- a/lib/string/string.go
+++ b/lib/string/string.go
@@ -201,10 +201,14 @@ func createIndexFunc(name string, reverse, returnNegative bool) func(thread *sta
 // substring returns a substring from start to end (exclusive) indices.
 func substring(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var (
-		s          string
-		start, end int
+		s     string
+		start int
+		endV  starlark.Value
 	)
-	if err := starlark.UnpackArgs("substring", args, kwargs, "s", &s, "start", &start, "end?", &end); err != nil {
+	// end is unpacked as a Value so that an omitted end (nil) is
+	// distinguishable from an explicit 0 or -len(s), which are honoured
+	// as given instead of silently meaning "to the end of the string".
+	if err := starlark.UnpackArgs("substring", args, kwargs, "s", &s, "start", &start, "end?", &endV); err != nil {
 		return none, err
 	}
 
@@ -212,15 +216,22 @@ func substring(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple
 	rs := []rune(s)
 	n := len(rs)
 
-	// Handle negative indices
+	// end defaults to the length of the string when omitted or None
+	end := n
+	if endV != nil && endV != starlark.None {
+		ei, err := starlark.AsInt32(endV)
+		if err != nil {
+			return none, fmt.Errorf(`substring: for parameter end: %w`, err)
+		}
+		end = ei
+		if end < 0 {
+			end += n
+		}
+	}
+
+	// Handle negative start index
 	if start < 0 {
 		start += n
-	}
-	if end < 0 {
-		end += n
-	}
-	if end == 0 { // if end is not provided, use the length of the string
-		end = n
 	}
 
 	// Check for out of range indices

--- a/lib/string/string_test.go
+++ b/lib/string/string_test.go
@@ -350,7 +350,39 @@ func TestLoadModule_String(t *testing.T) {
 				assert.eq(substring('你好世界', 2, -1), '世')
 				assert.eq(substring('a☕c', 1, 2), '☕')
 				assert.eq(substring('a☕c', -2, -1), '☕')
+				assert.eq(substring('hello', 3, 3), '')
 			`),
+		},
+		{
+			name: `substring with explicit zero end`,
+			script: itn.HereDoc(`
+				load('string', 'substring')
+				assert.eq(substring('hello', 0, 0), '')
+				assert.eq(substring('hello', 0, -5), '')
+			`),
+		},
+		{
+			name: `substring with none end`,
+			script: itn.HereDoc(`
+				load('string', 'substring')
+				assert.eq(substring('hello', 1, None), 'ello')
+			`),
+		},
+		{
+			name: `substring with explicit zero end after start`,
+			script: itn.HereDoc(`
+				load('string', 'substring')
+				substring('hello', 2, 0)
+			`),
+			wantErr: `substring: indices are out of range`,
+		},
+		{
+			name: `substring with invalid end type`,
+			script: itn.HereDoc(`
+				load('string', 'substring')
+				substring('hello', 1, '2')
+			`),
+			wantErr: `substring: for parameter end: got string, want int`,
 		},
 		{
 			name: `substring with missing end`,


### PR DESCRIPTION
## Why

`substring`'s optional `end` was unpacked into a Go `int`, so the zero value was indistinguishable from "not provided" and was silently rewritten to `len(s)` (Backlog **LET-06**, silent corruption):

- `substring('hello', 0, 0)` → `'hello'` (should be `''`)
- the same hack also swallowed an explicit `end=-len(s)` after negative-index adjustment: `substring('hello', 2, -5)` → `'llo'` (should be an out-of-range error)

## What

`end` is unpacked as a `starlark.Value`: `nil` (omitted) and `None` default to the string length; explicit values — including `0` and `-len(s)` — are honoured as given and go through the existing range checks. `end=None` is now accepted (Python slice parity). The error shape for a wrongly-typed `end` is unchanged (`for parameter end: got string, want int`).

Test-first: the three new cases (`(0,0)`, `(0,-5)`, `(2,0)`) fail on the old code and pass with the fix; the pre-existing default-end behaviour (`substring('hello', 1)` → `'ello'`) is pinned and unchanged. README updated to mark `end` optional and document the semantics.

## Behavior change

Only for inputs that previously hit the bug: `substring(s, x, 0)` / `substring(s, x, -len(s))` now return `''` (when `x == 0`) or an out-of-range error instead of the rest of the string.

Refs: LET-06

🤖 Generated with [Claude Code](https://claude.com/claude-code)