### PR TITLE
[fix] LET-07+LET-08: stop the legacy re module from silently lying

### DIFF
--- a/lib/re/README.md
+++ b/lib/re/README.md
@@ -1,101 +1,116 @@
 # re
 
-`re` defines regular expression functions, it's intended to be a drop-in subset of [Python's **re** module](https://docs.python.org/3/library/re.html) for Starlark.
+`re` defines regular expression functions, it's intended to be a subset of [Python's **re** module](https://docs.python.org/3/library/re.html) for Starlark, built on Go's [RE2 syntax](https://golang.org/s/re2syntax).
+
+Notable differences from Python's `re`:
+
+- **flags must be `0`**: numeric `re.*` flags are not supported and are rejected with an error. Use inline pattern flags like `(?i)`, `(?m)`, `(?s)` instead.
+- **`sub` replacement templates use Go syntax**: `$1` or `${name}` refers to a capture group and `$$` is a literal dollar sign. Python backslash references like `\1` are **not** interpreted, and a function `repl` is not supported.
+- **`split` does not include capture-group text** in its result.
+- There is no Match object: `match` returns a list of tuples and `search` returns an index pair (see below).
 
 ## Functions
 
-### `compile(pattern) Pattern`
+### `compile(pattern, flags=0) Pattern`
 
 Compile a regular expression pattern into a regular expression object, which
 can be used for matching using its match(), search() and other methods.
 
 #### Parameters
 
-| name      | type     | description                       |
-|-----------|----------|-----------------------------------|
-| `pattern` | `string` | regular expression pattern string |
+| name      | type     | description                                            |
+|-----------|----------|--------------------------------------------------------|
+| `pattern` | `string` | regular expression pattern string                      |
+| `flags`   | `int`    | must be 0; use inline flags like `(?i)` in the pattern |
 
-### `search(pattern,string,flags=0)`
+### `search(pattern, string, flags=0)`
 
 Scan through string looking for the first location where the regular expression pattern
-produces a match, and return a corresponding match object. Return None if no position in
-the string matches the pattern; note that this is different from finding a zero-length match
-at some point in the string.
+produces a match, and return the `[start, end]` byte-index pair of that match as a list.
+Return None if no position in the string matches the pattern; note that this is different
+from finding a zero-length match at some point in the string.
 
 #### Parameters
 
-| name      | type     | description                                                       |
-|-----------|----------|-------------------------------------------------------------------|
-| `pattern` | `string` | regular expression pattern string                                 |
-| `string`  | `string` | input string to search                                            |
-| `flags`   | `int`    | integer flags to control regex behaviour. reserved for future use |
+| name      | type     | description                                            |
+|-----------|----------|--------------------------------------------------------|
+| `pattern` | `string` | regular expression pattern string                      |
+| `string`  | `string` | input string to search                                 |
+| `flags`   | `int`    | must be 0; use inline flags like `(?i)` in the pattern |
 
 ### `findall(pattern, text, flags=0)`
 
-Returns all non-overlapping matches of pattern in string, as a list of strings.
+Returns all non-overlapping matches of pattern in string, as a tuple of strings.
 The string is scanned left-to-right, and matches are returned in the order found.
-If one or more groups are present in the pattern, return a list of groups;
-this will be a list of tuples if the pattern has more than one group.
+If one group is present in the pattern, the group text is returned instead of the
+full match; with several groups, each element is a tuple of the group texts.
 Empty matches are included in the result.
 
 #### Parameters
 
-| name      | type     | description                                                       |
-|-----------|----------|-------------------------------------------------------------------|
-| `pattern` | `string` | regular expression pattern string                                 |
-| `text`    | `string` | string to find within                                             |
-| `flags`   | `int`    | integer flags to control regex behaviour. reserved for future use |
+| name      | type     | description                                            |
+|-----------|----------|--------------------------------------------------------|
+| `pattern` | `string` | regular expression pattern string                      |
+| `text`    | `string` | string to find within                                  |
+| `flags`   | `int`    | must be 0; use inline flags like `(?i)` in the pattern |
 
 ### `split(pattern, text, maxsplit=0, flags=0)`
 
-Split text by the occurrences of pattern. If capturing parentheses are used in pattern,
-then the text of all groups in the pattern are also returned as part of the resulting list.
-If maxsplit is nonzero, at most maxsplit splits occur, and the remainder of the string
-is returned as the final element of the list.
+Split text by the occurrences of pattern. If maxsplit is positive, at most maxsplit
+splits occur, and the remainder of the string is returned as the final element of the
+result; a negative maxsplit means no splits happen at all. Note that unlike Python,
+the text of capture groups in the pattern is **not** included in the result.
 
 #### Parameters
 
-| name       | type     | description                                                       |
-|------------|----------|-------------------------------------------------------------------|
-| `pattern`  | `string` | regular expression pattern string                                 |
-| `text`     | `string` | input string to split                                             |
-| `maxsplit` | `int`    | maximum number of splits to make. default 0 splits all matches    |
-| `flags`    | `int`    | integer flags to control regex behaviour. reserved for future use |
+| name       | type     | description                                                            |
+|------------|----------|------------------------------------------------------------------------|
+| `pattern`  | `string` | regular expression pattern string                                      |
+| `text`     | `string` | input string to split                                                  |
+| `maxsplit` | `int`    | maximum number of splits. 0 (default) splits everywhere, negative none |
+| `flags`    | `int`    | must be 0; use inline flags like `(?i)` in the pattern                 |
 
 ### `sub(pattern, repl, text, count=0, flags=0)`
 
 Return the string obtained by replacing the leftmost non-overlapping occurrences of pattern
-in string by the replacement repl. If the pattern isn’t found, string is returned unchanged.
-repl can be a string or a function; if it is a string, any backslash escapes in it are processed.
-That is, `\n` is converted to a single newline character, `\r` is converted to a carriage return, and so forth.
+in string by the replacement repl. If the pattern isn't found, string is returned unchanged.
+repl must be a string and uses Go's template syntax: `$1` or `${name}` refers to a capture
+group and `$$` is a literal dollar sign; Python backslash references like `\1` are **not**
+interpreted.
 
 #### Parameters
 
-| name      | type     | description                                                         |
-|-----------|----------|---------------------------------------------------------------------|
-| `pattern` | `string` | regular expression pattern string                                   |
-| `repl`    | `string` | string to replace matches with                                      |
-| `text`    | `string` | input string to replace                                             |
-| `count`   | `int`    | number of replacements to make, default 0 means replace all matches |
-| `flags`   | `int`    | integer flags to control regex behaviour. reserved for future use   |
+| name      | type     | description                                                                |
+|-----------|----------|----------------------------------------------------------------------------|
+| `pattern` | `string` | regular expression pattern string                                          |
+| `repl`    | `string` | replacement template (`$1`/`${name}` for groups, `$$` for a literal `$`)   |
+| `text`    | `string` | input string to replace                                                    |
+| `count`   | `int`    | number of replacements. 0 (default) replaces all matches, negative none    |
+| `flags`   | `int`    | must be 0; use inline flags like `(?i)` in the pattern                     |
 
 ### `match(pattern, string, flags=0)`
 
-If zero or more characters at the beginning of string match the regular expression pattern,
-return a corresponding match string tuple. Return None if the string does not match the pattern
+If zero or more characters at the **beginning** of string match the regular expression
+pattern, return a list with a single tuple holding the full match followed by the text of
+every capture group. Return an empty list if the beginning of the string does not match
+the pattern — a match elsewhere in the string does not count; use `search()` or
+`findall()` for that.
 
 #### Parameters
 
-| name      | type     | description                       |
-|-----------|----------|-----------------------------------|
-| `pattern` | `string` | regular expression pattern string |
-| `string`  | `string` | input string to match             |
+| name      | type     | description                                            |
+|-----------|----------|--------------------------------------------------------|
+| `pattern` | `string` | regular expression pattern string                      |
+| `string`  | `string` | input string to match                                  |
+| `flags`   | `int`    | must be 0; use inline flags like `(?i)` in the pattern |
 
 ## Types
 
 ### `Pattern`
 
 **Methods**
+
+#### `search(text, flags=0)`
 
 #### `match(text, flags=0)`
 

--- a/lib/re/re.go
+++ b/lib/re/re.go
@@ -8,6 +8,7 @@
 package re
 
 import (
+	"fmt"
 	"regexp"
 	"sort"
 	"sync"
@@ -53,9 +54,8 @@ func LoadModule() (starlark.StringDict, error) {
 // Compile a regular expression pattern into a regular expression object, which
 // can be used for matching using its match(), search() and other methods.
 //
-// The expression’s behaviour can be modified by specifying a flags value.
-// Values can be any of the following variables, combined using bitwise OR
-// (the | operator).
+// flags must be 0: numeric re.* flags are not supported by this module and
+// are rejected loudly; use inline pattern flags like (?i), (?m), (?s) instead.
 func compile(thread *starlark.Thread, bn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var (
 		pattern starlark.String
@@ -65,20 +65,27 @@ func compile(thread *starlark.Thread, bn *starlark.Builtin, args starlark.Tuple,
 	if err := starlark.UnpackArgs(bn.Name(), args, kwargs, "pattern", &pattern, "flags?", &flags); err != nil {
 		return starlark.None, err
 	}
+	if err := checkFlags(bn.Name(), flags); err != nil {
+		return starlark.None, err
+	}
 
 	return newRegex(pattern)
 }
 
 // search(pattern,string,flags=0)
-// Scan through string looking for the first location where the regular expression pattern produces a match,
-// and return a corresponding match object. Return None if no position in the string matches the pattern;
-// note that this is different from finding a zero-length match at some point in the string.
+// Scan through string looking for the first location where the regular
+// expression pattern produces a match, and return the [start, end] byte-index
+// pair of that match as a list. Return None if no position in the string
+// matches the pattern. flags must be 0 (see compile).
 func search(thread *starlark.Thread, bn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var (
 		pattern, str starlark.String
 		flags        starlark.Int
 	)
 	if err := starlark.UnpackArgs(bn.Name(), args, kwargs, "pattern", &pattern, "string", &str, "flags?", &flags); err != nil {
+		return starlark.None, err
+	}
+	if err := checkFlags(bn.Name(), flags); err != nil {
 		return starlark.None, err
 	}
 	re, err := newGoRegex(pattern)
@@ -104,17 +111,21 @@ func reSearch(re *regexp.Regexp, str starlark.String, flags starlark.Int) (starl
 }
 
 // match(pattern, string, flags=0)
-// If zero or more characters at the beginning of string match the regular expression pattern,
-// return a corresponding match object. Return None if the string does not match the pattern;
-// note that this is different from a zero-length match.
-// Note that even in MULTILINE mode, re.match() will only match at the beginning of the string and not at the beginning of each line.
-// If you want to locate a match anywhere in string, use search() instead.
+// If zero or more characters at the beginning of string match the regular
+// expression pattern, return a list with a single tuple holding the full
+// match followed by the text of every capture group. Return an empty list
+// if the beginning of the string does not match the pattern (a match
+// elsewhere in the string does not count; use search() or findall() for
+// that). flags must be 0 (see compile).
 func match(thread *starlark.Thread, bn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var (
 		pattern, str starlark.String
 		flags        starlark.Int
 	)
 	if err := starlark.UnpackArgs(bn.Name(), args, kwargs, "pattern", &pattern, "string", &str, "flags?", &flags); err != nil {
+		return starlark.None, err
+	}
+	if err := checkFlags(bn.Name(), flags); err != nil {
 		return starlark.None, err
 	}
 
@@ -127,8 +138,16 @@ func match(thread *starlark.Thread, bn *starlark.Builtin, args starlark.Tuple, k
 }
 
 func reMatch(re *regexp.Regexp, str starlark.String, flags starlark.Int) (starlark.Value, error) {
+	// match() is documented to match only at the beginning of the string
+	// (Python semantics), so anchor the pattern. The historical
+	// implementation scanned the whole string like findall, which inverted
+	// the truthiness of `if match(...)` checks ported from Python.
+	are, err := regexp.Compile(`\A(?:` + re.String() + `)`)
+	if err != nil {
+		return starlark.None, err
+	}
 	vals := starlark.NewList(nil)
-	for _, match := range re.FindAllStringSubmatch(string(str), -1) {
+	for _, match := range are.FindAllStringSubmatch(string(str), 1) {
 		if err := vals.Append(slStrSlice(match)); err != nil {
 			return starlark.None, err
 		}
@@ -149,16 +168,20 @@ func reMatch(re *regexp.Regexp, str starlark.String, flags starlark.Int) (starla
 // }
 
 // split(pattern, string, maxsplit=0, flags=0)
-// Split string by the occurrences of pattern. If capturing parentheses are used in pattern,
-// then the text of all groups in the pattern are also returned as part of the resulting list.
-// If maxsplit is nonzero, at most maxsplit splits occur, and the remainder of the string
-// is returned as the final element of the list.
+// Split string by the occurrences of pattern. If maxsplit is positive, at
+// most maxsplit splits occur, and the remainder of the string is returned
+// as the final element; a negative maxsplit means no splits happen at all.
+// Note that unlike Python, the text of capture groups in the pattern is
+// NOT included in the result. flags must be 0 (see compile).
 func split(thread *starlark.Thread, bn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var (
 		pattern, str    starlark.String
 		maxSplit, flags starlark.Int
 	)
-	if err := starlark.UnpackArgs(bn.Name(), args, kwargs, "pattern", &pattern, "string", &str, "maxsplit?", &maxSplit, "flags", &flags); err != nil {
+	if err := starlark.UnpackArgs(bn.Name(), args, kwargs, "pattern", &pattern, "string", &str, "maxsplit?", &maxSplit, "flags?", &flags); err != nil {
+		return starlark.None, err
+	}
+	if err := checkFlags(bn.Name(), flags); err != nil {
 		return starlark.None, err
 	}
 
@@ -171,22 +194,31 @@ func split(thread *starlark.Thread, bn *starlark.Builtin, args starlark.Tuple, k
 }
 
 func reSplit(re *regexp.Regexp, str starlark.String, maxSplit, flags starlark.Int) (starlark.Value, error) {
-	ms, _ := maxSplit.Int64()
-	if ms == 0 {
-		// -1 is the sentinel for "all" in go, not 0
-		ms = -1
+	ms, ok := maxSplit.Int64()
+	if !ok || ms > 1<<30 {
+		ms = 0 // an astronomically large maxsplit behaves like "no limit"
 	}
-
-	res := re.Split(string(str), int(ms))
-	return slStrSlice(res), nil
+	switch {
+	case ms < 0:
+		// Python semantics: a negative maxsplit means no splits at all
+		return slStrSlice([]string{string(str)}), nil
+	case ms == 0:
+		// 0 means "split everywhere"; -1 is the sentinel for "all" in Go
+		return slStrSlice(re.Split(string(str), -1)), nil
+	default:
+		// Go's n counts resulting substrings, Python's maxsplit counts
+		// splits, so n = maxsplit + 1
+		return slStrSlice(re.Split(string(str), int(ms)+1)), nil
+	}
 }
 
 // findall(pattern, string, flags=0)
-// Returns all non-overlapping matches of pattern in string, as a list of strings.
-// The string is scanned left-to-right, and matches are returned in the order found.
-// If one or more groups are present in the pattern, return a list of groups;
-// this will be a list of tuples if the pattern has more than one group.
-// Empty matches are included in the result.
+// Returns all non-overlapping matches of pattern in string, as a tuple of
+// strings. The string is scanned left-to-right, and matches are returned in
+// the order found. If one group is present in the pattern, the group text is
+// returned instead of the full match; with several groups each element is a
+// tuple of the group texts. Empty matches are included in the result.
+// flags must be 0 (see compile).
 func findall(thread *starlark.Thread, bn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var (
 		pattern starlark.String
@@ -194,6 +226,9 @@ func findall(thread *starlark.Thread, bn *starlark.Builtin, args starlark.Tuple,
 		flags   starlark.Int
 	)
 	if err := starlark.UnpackArgs(bn.Name(), args, kwargs, "pattern", &pattern, "string", &str, "flags?", &flags); err != nil {
+		return starlark.None, err
+	}
+	if err := checkFlags(bn.Name(), flags); err != nil {
 		return starlark.None, err
 	}
 
@@ -205,8 +240,23 @@ func findall(thread *starlark.Thread, bn *starlark.Builtin, args starlark.Tuple,
 }
 
 func reFindall(re *regexp.Regexp, str starlark.String, flags starlark.Int) (starlark.Value, error) {
-	res := re.FindAllString(string(str), -1)
-	return slStrSlice(res), nil
+	// Python shaping: no capture groups -> the full match text; one group ->
+	// that group's text; several groups -> a tuple of the group texts.
+	// The historical implementation always returned the full match and
+	// silently dropped the groups its own docstring promised.
+	ng := re.NumSubexp()
+	var vals starlark.Tuple
+	for _, m := range re.FindAllStringSubmatch(string(str), -1) {
+		switch ng {
+		case 0:
+			vals = append(vals, starlark.String(m[0]))
+		case 1:
+			vals = append(vals, starlark.String(m[1]))
+		default:
+			vals = append(vals, slStrSlice(m[1:]))
+		}
+	}
+	return vals, nil
 }
 
 // func finditer(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
@@ -219,31 +269,63 @@ func reFindall(re *regexp.Regexp, str starlark.String, flags starlark.Int) (star
 // }
 
 // sub(pattern, repl, string, count=0, flags=0)
-// Return the string obtained by replacing the leftmost non-overlapping occurrences of pattern
-// in string by the replacement repl. If the pattern isn’t found, string is returned unchanged.
-// repl can be a string or a function; if it is a string, any backslash escapes in it are processed.
-// That is, \n is converted to a single newline character, \r is converted to a carriage return, and so forth.
-// Unknown escapes such as \& are left alone. Backreferences, such as \6, are replaced with the substring matched by group 6 in the pattern.
+// Return the string obtained by replacing the leftmost non-overlapping
+// occurrences of pattern in string by the replacement repl. If the pattern
+// isn't found, string is returned unchanged. count limits the number of
+// replacements: 0 (the default) replaces all occurrences, and a negative
+// count replaces nothing. repl must be a string and uses Go's template
+// syntax: $1 or ${name} refers to a capture group and $$ is a literal
+// dollar sign — Python backslash references like \1 are NOT interpreted,
+// and a function repl is not supported. flags must be 0 (see compile).
 func sub(thread *starlark.Thread, bn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var (
 		pattern, repl, str starlark.String
 		count, flags       starlark.Int
 	)
-	if err := starlark.UnpackArgs(bn.Name(), args, kwargs, "pattern", &pattern, "repl", &repl, "string", &str, "count?", &count, "flags", &flags); err != nil {
+	if err := starlark.UnpackArgs(bn.Name(), args, kwargs, "pattern", &pattern, "repl", &repl, "string", &str, "count?", &count, "flags?", &flags); err != nil {
+		return starlark.None, err
+	}
+	if err := checkFlags(bn.Name(), flags); err != nil {
 		return starlark.None, err
 	}
 
 	re, err := newGoRegex(pattern)
 	if err != nil {
-		return starlark.None, nil
+		// the historical code swallowed this error and returned None, which
+		// let an invalid dynamic pattern propagate silently as a None value
+		return starlark.None, err
 	}
 
 	return reSub(re, repl, str, count, flags)
 }
 
 func reSub(re *regexp.Regexp, repl, str starlark.String, count, flags starlark.Int) (starlark.Value, error) {
-	res := re.ReplaceAllString(string(str), string(repl))
-	return starlark.String(res), nil
+	s := string(str)
+	n, ok := count.Int64()
+	if !ok {
+		n = 0 // an astronomically large count behaves like "replace all"
+	}
+	switch {
+	case n < 0:
+		// Python semantics: a negative count means no replacements
+		return str, nil
+	case n == 0:
+		// 0 means "replace all occurrences"
+		return starlark.String(re.ReplaceAllString(s, string(repl))), nil
+	default:
+		// replace only the first n matches; ExpandString shares the same
+		// $-template engine as ReplaceAllString, so replaced segments are
+		// byte-identical to the replace-all path
+		var b []byte
+		last := 0
+		for _, m := range re.FindAllStringSubmatchIndex(s, int(n)) {
+			b = append(b, s[last:m[0]]...)
+			b = re.ExpandString(b, string(repl), s, m)
+			last = m[1]
+		}
+		b = append(b, s[last:]...)
+		return starlark.String(b), nil
+	}
 }
 
 // subn(pattern, repl, string, count=0, flags=0)
@@ -268,6 +350,19 @@ func reSub(re *regexp.Regexp, repl, str starlark.String, count, flags starlark.I
 
 func newGoRegex(pattern starlark.String) (*regexp.Regexp, error) {
 	return regexp.Compile(string(pattern))
+}
+
+// checkFlags rejects any non-zero flags value. The flags parameter was
+// historically accepted and silently ignored, so Python-style numeric flags
+// (e.g. re.IGNORECASE == 2) appeared to work while matching with default
+// behaviour — a silent-wrong outcome. The module exports no flag constants,
+// so any non-zero value is a porting mistake; fail loudly and point at the
+// supported alternative.
+func checkFlags(name string, flags starlark.Int) error {
+	if flags.Sign() != 0 {
+		return fmt.Errorf("%s: flags are not supported by this module, use inline flags like (?i) in the pattern instead", name)
+	}
+	return nil
 }
 
 func slStrSlice(strs []string) starlark.Tuple {
@@ -355,6 +450,9 @@ func compiledSearch(fnname string, recV starlark.Value, args starlark.Tuple, kwa
 	if err := starlark.UnpackArgs("search", args, kwargs, "string", &str, "flags?", &flags); err != nil {
 		return starlark.None, err
 	}
+	if err := checkFlags(fnname, flags); err != nil {
+		return starlark.None, err
+	}
 
 	r := recV.(*Regex)
 	return reSearch(r.re, str, flags)
@@ -368,6 +466,9 @@ func compiledMatch(fnname string, recV starlark.Value, args starlark.Tuple, kwar
 	if err := starlark.UnpackArgs("match", args, kwargs, "string", &str, "flags?", &flags); err != nil {
 		return starlark.None, err
 	}
+	if err := checkFlags(fnname, flags); err != nil {
+		return starlark.None, err
+	}
 
 	r := recV.(*Regex)
 	return reMatch(r.re, str, flags)
@@ -378,7 +479,10 @@ func compiledSplit(fnname string, recV starlark.Value, args starlark.Tuple, kwar
 		str             starlark.String
 		maxSplit, flags starlark.Int
 	)
-	if err := starlark.UnpackArgs("split", args, kwargs, "string", &str, "maxsplit?", &maxSplit, "flags", &flags); err != nil {
+	if err := starlark.UnpackArgs("split", args, kwargs, "string", &str, "maxsplit?", &maxSplit, "flags?", &flags); err != nil {
+		return starlark.None, err
+	}
+	if err := checkFlags(fnname, flags); err != nil {
 		return starlark.None, err
 	}
 
@@ -394,6 +498,9 @@ func compiledFindall(fnname string, recV starlark.Value, args starlark.Tuple, kw
 	if err := starlark.UnpackArgs("findall", args, kwargs, "string", &str, "flags?", &flags); err != nil {
 		return starlark.None, err
 	}
+	if err := checkFlags(fnname, flags); err != nil {
+		return starlark.None, err
+	}
 
 	r := recV.(*Regex)
 	return reFindall(r.re, str, flags)
@@ -404,7 +511,10 @@ func compiledSub(fnname string, recV starlark.Value, args starlark.Tuple, kwargs
 		repl, str    starlark.String
 		count, flags starlark.Int
 	)
-	if err := starlark.UnpackArgs("sub", args, kwargs, "repl", &repl, "string", &str, "count?", &count, "flags", &flags); err != nil {
+	if err := starlark.UnpackArgs("sub", args, kwargs, "repl", &repl, "string", &str, "count?", &count, "flags?", &flags); err != nil {
+		return starlark.None, err
+	}
+	if err := checkFlags(fnname, flags); err != nil {
 		return starlark.None, err
 	}
 

--- a/lib/re/re_test.go
+++ b/lib/re/re_test.go
@@ -311,6 +311,16 @@ func TestLoadModule_Re(t *testing.T) {
 			`),
 			wantErr: `sub: flags are not supported`,
 		},
+		{
+			name: `compiled search and attrs`,
+			script: itn.HereDoc(`
+			load('re', 'compile')
+			b = compile('b')
+			assert.eq(b.search('abc'), [1, 2])
+			assert.eq(b.search('xyz'), None)
+			assert.eq(dir(b), ["findall", "match", "search", "split", "sub"])
+			`),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/lib/re/re_test.go
+++ b/lib/re/re_test.go
@@ -248,6 +248,69 @@ func TestLoadModule_Re(t *testing.T) {
 			`),
 			wantErr: `findall: flags are not supported`,
 		},
+		{
+			name: `split huge maxsplit`,
+			script: itn.HereDoc(`
+			load('re', 'split')
+			assert.eq(split(',', 'a,b,c', 1 << 40), ('a', 'b', 'c'))
+			assert.eq(split(',', 'a,b,c', 1 << 80), ('a', 'b', 'c'))
+			`),
+		},
+		{
+			name: `sub huge count`,
+			script: itn.HereDoc(`
+			load('re', 'sub')
+			assert.eq(sub('a', 'X', 'aaa', 1 << 80), 'XXX')
+			`),
+		},
+		{
+			name: `search flags rejected`,
+			script: itn.HereDoc(`
+			load('re', 'search')
+			search('a', 'a', flags=1)
+			`),
+			wantErr: `re.search: flags are not supported`,
+		},
+		{
+			name: `match flags rejected`,
+			script: itn.HereDoc(`
+			load('re', 'match')
+			match('a', 'a', flags=1)
+			`),
+			wantErr: `re.match: flags are not supported`,
+		},
+		{
+			name: `compiled search flags rejected`,
+			script: itn.HereDoc(`
+			load('re', 'compile')
+			compile('a').search('a', flags=1)
+			`),
+			wantErr: `search: flags are not supported`,
+		},
+		{
+			name: `compiled match flags rejected`,
+			script: itn.HereDoc(`
+			load('re', 'compile')
+			compile('a').match('a', flags=1)
+			`),
+			wantErr: `match: flags are not supported`,
+		},
+		{
+			name: `compiled split flags rejected`,
+			script: itn.HereDoc(`
+			load('re', 'compile')
+			compile('a').split('a', flags=1)
+			`),
+			wantErr: `split: flags are not supported`,
+		},
+		{
+			name: `compiled sub flags rejected`,
+			script: itn.HereDoc(`
+			load('re', 'compile')
+			compile('a').sub('x', 'a', flags=1)
+			`),
+			wantErr: `sub: flags are not supported`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/lib/re/re_test.go
+++ b/lib/re/re_test.go
@@ -142,6 +142,112 @@ func TestLoadModule_Re(t *testing.T) {
 			`),
 			wantErr: `re.findall: for parameter pattern: got int, want string`,
 		},
+		{
+			name: `sub invalid pattern`,
+			script: itn.HereDoc(`
+			load('re', 'sub')
+			sub('(', 'x', 'abc')
+			`),
+			wantErr: `missing closing`,
+		},
+		{
+			name: `sub with count`,
+			script: itn.HereDoc(`
+			load('re', 'sub')
+			assert.eq(sub('a', 'X', 'aaa', 1), 'Xaa')
+			assert.eq(sub('a', 'X', 'aaa', count=2), 'XXa')
+			assert.eq(sub('a', 'X', 'aaa', 9), 'XXX')
+			assert.eq(sub('a', 'X', 'aaa', 0), 'XXX')
+			assert.eq(sub('a', 'X', 'aaa', -1), 'aaa')
+			`),
+		},
+		{
+			name: `sub group template`,
+			script: itn.HereDoc(`
+			load('re', 'sub')
+			assert.eq(sub('(a)(b)', '${2}${1}', 'ab ab'), 'ba ba')
+			assert.eq(sub('a', '$$5', 'a'), '$5')
+			`),
+		},
+		{
+			name: `sub flags rejected`,
+			script: itn.HereDoc(`
+			load('re', 'sub')
+			sub('a', 'b', 'c', 0, 2)
+			`),
+			wantErr: `re.sub: flags are not supported`,
+		},
+		{
+			name: `split maxsplit`,
+			script: itn.HereDoc(`
+			load('re', 'split')
+			assert.eq(split(',', 'a,b,c', 1), ('a', 'b,c'))
+			assert.eq(split(',', 'a,b,c', maxsplit=2), ('a', 'b', 'c'))
+			assert.eq(split(',', 'a,b,c', 99), ('a', 'b', 'c'))
+			assert.eq(split(',', 'a,b,c', -1), ('a,b,c',))
+			`),
+		},
+		{
+			name: `split flags rejected`,
+			script: itn.HereDoc(`
+			load('re', 'split')
+			split(',', 'a,b', 0, 1)
+			`),
+			wantErr: `re.split: flags are not supported`,
+		},
+		{
+			name: `match anchored`,
+			script: itn.HereDoc(`
+			load('re', 'match')
+			assert.eq(match('world', 'hello world'), [])
+			assert.eq(match('hello', 'hello world'), [('hello',)])
+			assert.eq(match('(h)(e)', 'hello'), [('he', 'h', 'e')])
+			`),
+		},
+		{
+			name: `findall groups`,
+			script: itn.HereDoc(`
+			load('re', 'findall')
+			assert.eq(findall(r'(\w)(\d)', 'a1 b2'), (('a', '1'), ('b', '2')))
+			assert.eq(findall(r'\w(\d)', 'a1 b2'), ('1', '2'))
+			`),
+		},
+		{
+			name: `findall flags rejected`,
+			script: itn.HereDoc(`
+			load('re', 'findall')
+			findall('a', 'a', flags=1)
+			`),
+			wantErr: `re.findall: flags are not supported`,
+		},
+		{
+			name: `compile flags rejected`,
+			script: itn.HereDoc(`
+			load('re', 'compile')
+			compile('a', 1)
+			`),
+			wantErr: `re.compile: flags are not supported`,
+		},
+		{
+			name: `compiled methods semantics`,
+			script: itn.HereDoc(`
+			load('re', 'compile')
+			c = compile(',')
+			assert.eq(c.split('a,b,c', 1), ('a', 'b,c'))
+			a = compile('a')
+			assert.eq(a.sub('X', 'aaa', 2), 'XXa')
+			assert.eq(a.match('abc'), [('a',)])
+			assert.eq(a.match('bca'), [])
+			`),
+		},
+		{
+			name: `compiled flags rejected`,
+			script: itn.HereDoc(`
+			load('re', 'compile')
+			compile('a').findall('a', flags=1)
+			`),
+			wantErr: `findall: flags are not supported`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Why

The `re` module was migrated verbatim from its upstream source, inheriting a family of **silent-wrong** behaviors — results that differ from both Python semantics and the module's own docstrings, with no error raised (Backlog **LET-07**, **LET-08**). This PR is the minimal honesty pass for the frozen legacy module: **no Match object, no new API** — a full Python-semantics regex module is planned separately.

## Behavior fixes

| defect | before | after |
|---|---|---|
| `sub` swallowed pattern errors | `sub('(', 'x', s)` → `None`, no error (the only sibling that dropped the compile error) | the error is returned |
| `sub` ignored `count` | `sub(p, r, s, count=1)` replaced **all** occurrences — data corruption | counted replace (`FindAllStringSubmatchIndex` + `ExpandString`, same template engine as `ReplaceAllString`); negative count replaces nothing (Python semantics) |
| `split` maxsplit off-by-one | Go's `Split(n)` counts *substrings*, Python's maxsplit counts *splits*: `split(',', 'a,b,c', maxsplit=1)` returned the string unsplit; negative meant "split all" | `n = maxsplit+1`; negative = no splits |
| `findall` dropped groups | used `FindAllString` despite the docstring promising group shaping | Python shaping: 0 groups → full match, 1 group → group text, 2+ → tuple |
| `match` not anchored | scanned the whole string like findall — `match('world', 'hello world')` was truthy, **inverting** `if match(...)` checks ported from Python, against its own docstring | pattern anchored at the beginning of the string |
| `flags` silently ignored | accepted on all 11 entry points, ignored everywhere (`re.IGNORECASE == 2` silently no-opped) | non-zero flags **fail loudly**, pointing at inline `(?i)`/`(?m)`/`(?s)` |
| **LET-08**: `flags` not optional in 4 sites | all-positional `re.sub(p, r, s, 1)` failed with `missing argument for flags` (split/sub + compiled variants) | `flags?` everywhere, consistent with search/match/findall |

LET-07 and LET-08 land together deliberately: making flags optional without the loud rejection would turn the positional-flags call form into a *new* silent no-op, and the rejection without the `?` fix leaves the documented call forms broken — only together do the semantics close.

## Docs

`re.go` docstrings + README now state the actual semantics: `sub`'s Go `$`-template replacement syntax (`$1`/`${name}`/`$$`; Python `\1` backrefs are **not** interpreted — kept as-is for now since existing scripts may rely on `$1`, final semantics belong to the future regex module), `split` not returning group text, `search`'s index-pair return shape, and the flags policy.

## Tests

Test-first: 11 new table cases covering every fix fail on the old code; `sub group template` pins the $-template behavior; all pre-existing cases (including `match` against position-0 patterns and compiled-object methods) pass unchanged.

Refs: LET-07, LET-08

🤖 Generated with [Claude Code](https://claude.com/claude-code)