### PR TITLE
[fix] LET-01: csv writes cells per type instead of Go %v rendering

### DIFF
--- a/lib/csv/README.md
+++ b/lib/csv/README.md
@@ -59,6 +59,8 @@ print(data)
 
 write all rows from source to a csv-encoded string
 
+Cell values are rendered per type: strings as-is; ints and floats in plain decimal notation (never scientific, e.g. `1000000.0` → `1000000`); `True`/`False` as `true`/`false`; `None` as an empty cell; time values as RFC 3339. Nested lists/dicts and non-finite floats (`nan`, `inf`) are reported as errors instead of being silently written in Go syntax.
+
 #### Parameters
 
 | name     | type         | description                                                                                                                                                     |
@@ -88,6 +90,8 @@ print(csv_str)
 ### `write_dict(data, header, comma=",") string`
 
 write a list of dictionaries to a csv string based on the provided header
+
+Cell values are rendered with the same per-type rules as `write_all`; a key missing from a row produces an empty cell, the same as an explicit `None`.
 
 #### Parameters
 

--- a/lib/csv/csv.go
+++ b/lib/csv/csv.go
@@ -7,7 +7,10 @@ import (
 	"bytes"
 	"encoding/csv"
 	"fmt"
+	"math"
+	"strconv"
 	"sync"
+	"time"
 
 	"github.com/1set/starlet/dataconv"
 	tps "github.com/1set/starlet/dataconv/types"
@@ -16,6 +19,41 @@ import (
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 )
+
+// cellToString renders a single cell value for CSV output. Every supported
+// type is rendered explicitly: the previous fmt.Sprintf("%v", v) silently
+// produced Go-flavored text — scientific notation for large/small floats
+// ("1e+06"), "<nil>" for None, Go syntax for nested collections — which
+// corrupted the written file without any error.
+func cellToString(v interface{}) (string, error) {
+	switch c := v.(type) {
+	case nil:
+		// matches the empty cell written for a missing write_dict key
+		return "", nil
+	case string:
+		return c, nil
+	case bool:
+		// lowercase, consistent with json.encode output
+		if c {
+			return "true", nil
+		}
+		return "false", nil
+	case int:
+		return strconv.Itoa(c), nil
+	case float64:
+		if math.IsNaN(c) || math.IsInf(c, 0) {
+			return "", fmt.Errorf("float value %v is not representable in CSV", c)
+		}
+		// plain decimal notation, never scientific: 1000000.0 -> "1000000"
+		return strconv.FormatFloat(c, 'f', -1, 64), nil
+	case time.Time:
+		return c.Format(time.RFC3339), nil
+	default:
+		// nested lists/dicts and anything else would serialize as Go syntax
+		// ("[1 a]" / "map[a:1]") — reject loudly instead of corrupting
+		return "", fmt.Errorf("unsupported cell type %T", v)
+	}
+}
 
 // ModuleName defines the expected name for this Module when used in starlark's load() function, eg: load('csv', 'read_all')
 const ModuleName = "csv"
@@ -155,7 +193,11 @@ func writeAll(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple,
 		}
 		var row = make([]string, len(sl))
 		for j, v := range sl {
-			row[j] = fmt.Sprintf("%v", v)
+			cell, err := cellToString(v)
+			if err != nil {
+				return starlark.None, fmt.Errorf("%s: row %d column %d: %w", b.Name(), i, j, err)
+			}
+			row[j] = cell
 		}
 		records = append(records, row)
 	}
@@ -227,7 +269,11 @@ func writeDict(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple
 		var row = make([]string, len(headerStr))
 		for j, k := range headerStr {
 			if v, ok := mm[k]; ok {
-				row[j] = fmt.Sprintf("%v", v)
+				cell, err := cellToString(v)
+				if err != nil {
+					return starlark.None, fmt.Errorf("%s: row %d field %q: %w", b.Name(), len(records)-1, k, err)
+				}
+				row[j] = cell
 			}
 		}
 		records = append(records, row)

--- a/lib/csv/csv_test.go
+++ b/lib/csv/csv_test.go
@@ -2,9 +2,12 @@ package csv_test
 
 import (
 	"testing"
+	"time"
 
 	itn "github.com/1set/starlet/internal"
 	libcsv "github.com/1set/starlet/lib/csv"
+	startime "go.starlark.net/lib/time"
+	"go.starlark.net/starlark"
 )
 
 func TestLoadModule_CSV(t *testing.T) {
@@ -216,6 +219,31 @@ assert.eq(write_all(csv_data), csv_data_string)
 			`),
 		},
 		{
+			name: `write_all: cell types`,
+			script: itn.HereDoc(`
+load('csv', 'write_all')
+assert.eq(write_all([[1000000.0, 0.00001, -2.5]]), "1000000,0.00001,-2.5\n")
+assert.eq(write_all([[None, True, False]]), ",true,false\n")
+assert.eq(write_all([[test_time]]), "2023-01-15T12:30:45Z\n")
+			`),
+		},
+		{
+			name: `write_all: non-finite float cell`,
+			script: itn.HereDoc(`
+load('csv', 'write_all')
+write_all([[float("nan")]])
+			`),
+			wantErr: `not representable in CSV`,
+		},
+		{
+			name: `write_all: nested cell`,
+			script: itn.HereDoc(`
+load('csv', 'write_all')
+write_all([[[1, 2]]])
+			`),
+			wantErr: `unsupported cell type`,
+		},
+		{
 			name: `write_dict: no args`,
 			script: itn.HereDoc(`
 load('csv', 'write_dict')
@@ -298,6 +326,22 @@ assert.eq(x, "a\n100\n")
 			`),
 		},
 		{
+			name: `write_dict: cell types`,
+			script: itn.HereDoc(`
+load('csv', 'write_dict')
+x = write_dict([{"a": 1000000.0, "b": None, "c": True}], header=["a", "b", "c", "d"])
+assert.eq(x, "a,b,c,d\n1000000,,true,\n")
+			`),
+		},
+		{
+			name: `write_dict: nested cell`,
+			script: itn.HereDoc(`
+load('csv', 'write_dict')
+write_dict([{"a": {"x": 1}}], header=["a"])
+			`),
+			wantErr: `unsupported cell type`,
+		},
+		{
 			name: `write_dict: normal`,
 			script: itn.HereDoc(`
 load('csv', 'write_dict')
@@ -349,7 +393,10 @@ assert.eq(len(first_field), 1)  # Length should be 1, not 4 (3 BOM bytes + "a")
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res, err := itn.ExecModuleWithErrorTest(t, libcsv.ModuleName, libcsv.LoadModule, tt.script, tt.wantErr, nil)
+			predecl := starlark.StringDict{
+				"test_time": startime.Time(time.Date(2023, 1, 15, 12, 30, 45, 0, time.UTC)),
+			}
+			res, err := itn.ExecModuleWithErrorTest(t, libcsv.ModuleName, libcsv.LoadModule, tt.script, tt.wantErr, predecl)
 			if (err != nil) != (tt.wantErr != "") {
 				t.Errorf("csv(%q) expects error = '%v', actual error = '%v', result = %v", tt.name, tt.wantErr, err, res)
 				return


### PR DESCRIPTION
## Why

`write_all`/`write_dict` stringified every cell with `fmt.Sprintf("%v")`, silently writing Go-flavored text (Backlog **LET-01**, the highest-priority S patch — silent data corruption):

- `1000000.0` → `"1e+06"`, `0.00001` → `"1e-05"` (scientific notation; CSV round-trip broken)
- `None` → `"<nil>"`
- time values → Go's debug format (`2026-06-12 01:02:03 +0000 UTC`)
- nested lists/dicts → Go syntax (`"[1 a]"` / `"map[a:1]"`) — Backlog only listed float/None/bool; these are the same disease

## What

A single explicit per-type renderer (`cellToString`) feeds both write sites:

| value | before | after |
|---|---|---|
| `1000000.0` | `1e+06` | `1000000` |
| `None` | `<nil>` | empty cell (same as write_dict's missing key) |
| `True` | `true` | `true` (unchanged, json-consistent) |
| time | Go debug format | RFC 3339 |
| `nan`/`inf` | `NaN` | **error** (row/column named) |
| nested list/dict | `[1 2]` | **error** (row/column named) |

## Behavior change

Output text changes for float/None/time cells (bugfix-level: the old text was not round-trippable); nested/non-finite cells now error instead of writing junk. Scripts relying on parsing `"<nil>"` or scientific notation would notice — README documents the rules.

Test-first: five new cases fail on the old code; the existing int/string cases are unchanged and stay green.

Refs: LET-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)