### PR TITLE
[test] LET-02 follow-up: cover read_dict error paths and variable-field rows

### DIFF
--- a/lib/csv/csv_test.go
+++ b/lib/csv/csv_test.go
@@ -218,6 +218,46 @@ read_dict('a,b\n1\n')
 			wantErr: `wrong number of fields`,
 		},
 		{
+			name: `read_dict: no args`,
+			script: itn.HereDoc(`
+load('csv', 'read_dict')
+read_dict()
+			`),
+			wantErr: `csv.read_dict: missing argument for source`,
+		},
+		{
+			name: `read_dict: invalid comma`,
+			script: itn.HereDoc(`
+load('csv', 'read_dict')
+read_dict('a,b\n', comma=', ')
+			`),
+			wantErr: `csv.read_dict: expected comma param to be a single-character string`,
+		},
+		{
+			name: `read_dict: malformed header`,
+			script: itn.HereDoc(`
+load('csv', 'read_dict')
+read_dict('"bad\n')
+			`),
+			wantErr: `csv.read_dict: parse error on line 1`,
+		},
+		{
+			name: `read_dict: malformed data row`,
+			script: itn.HereDoc(`
+load('csv', 'read_dict')
+read_dict('a,b\n"bad\n')
+			`),
+			wantErr: `csv.read_dict: parse error on line 2`,
+		},
+		{
+			name: `read_dict: variable fields`,
+			script: itn.HereDoc(`
+load('csv', 'read_dict')
+rows = read_dict('a\n1,2\n3\n', fields_per_record=-1)
+assert.eq(rows, [{"a": "1"}, {"a": "3"}])
+			`),
+		},
+		{
 			name: `try_read_dict: error`,
 			script: itn.HereDoc(`
 load('csv', 'try_read_dict')


### PR DESCRIPTION
#134 was merged while `codecov/project` was still red (process slip on my side — the test legs were green and `codecov/patch` passed, but the project status had dipped on the new defensive branches and I merged without gating on it).

This covers the five reachable `readDict` branches that were missed: argument-unpacking errors, invalid comma, malformed header, malformed data row mid-stream, and extra-cell truncation under `fields_per_record=-1`. lib/csv goes from 95.3% back up; the only intentionally-uncovered remainder is the unreachable defensive `res == nil` arm of `wrapTry`.

Process correction going forward: merges gate on `gh pr checks` exiting 0 (codecov statuses land after the test jobs finish — test-green alone is not the bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)