### PR TITLE
[fix] LET-15: typed load() errors instead of the misleading filesystem message

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -3,6 +3,7 @@ package starlet
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"sync"
 	"sync/atomic"
 	"unsafe"
@@ -108,6 +109,18 @@ func (c *cache) doLoad(cc *cycleChecker, module string) (starlark.StringDict, er
 	// 2: load from source file
 	b, err := c.readFile(module)
 	if err != nil {
+		// A missing file or an absent filesystem means the name was found
+		// nowhere; report a typed error that names the module instead of
+		// surfacing the misleading filesystem message ("no file system
+		// given"). A name that matches a known builtin must have been
+		// deliberately left out of this machine's module set — withheld —
+		// which is different from a misspelled or unknown name.
+		if errors.Is(err, errNoFS) || errors.Is(err, fs.ErrNotExist) {
+			if _, known := allBuiltinModules[module]; known {
+				return nil, ModuleWithheldError{Name: module}
+			}
+			return nil, ModuleNotFoundError{Name: module}
+		}
 		return nil, err
 	}
 

--- a/error.go
+++ b/error.go
@@ -92,3 +92,32 @@ func errorStarlightConvert(target string, err error) ExecError {
 		cause: err,
 	}
 }
+
+// ModuleNotFoundError is returned by load() when the named module is not
+// present in any source available to the machine: it is neither a builtin
+// or custom loader configured for this machine, nor a script file on the
+// configured filesystem. Hosts can detect it with errors.As through the
+// Starlark error chain.
+type ModuleNotFoundError struct {
+	Name string
+}
+
+// Error returns the error message.
+func (e ModuleNotFoundError) Error() string {
+	return fmt.Sprintf("module %q not found in builtin modules, custom loaders, or the script filesystem", e.Name)
+}
+
+// ModuleWithheldError marks a module that exists but is deliberately not
+// made available to the current machine: a known builtin that was not
+// enabled, or a module blocked by a host-side policy layer (which can
+// return this type from its own loaders). It lets hosts and script authors
+// tell a misspelled module apart from a forbidden one; detect it with
+// errors.As through the Starlark error chain.
+type ModuleWithheldError struct {
+	Name string
+}
+
+// Error returns the error message.
+func (e ModuleWithheldError) Error() string {
+	return fmt.Sprintf("module %q is withheld and not available to this machine", e.Name)
+}

--- a/module.go
+++ b/module.go
@@ -212,6 +212,11 @@ func MakeModuleLoaderFromFile(name string, fileSys fs.FS, predeclared starlark.S
 	}
 }
 
+// errNoFS is returned by readScriptFile when no filesystem is configured;
+// the cache's load() path matches it to produce a typed not-found error
+// instead of surfacing the misleading filesystem message for module names.
+var errNoFS = errors.New("no file system given")
+
 // readScriptFile reads a script file from the given file system.
 // No need to wrap errors because they are usually used by the Starlark thread.
 func readScriptFile(name string, fileSys fs.FS) ([]byte, error) {
@@ -220,7 +225,7 @@ func readScriptFile(name string, fileSys fs.FS) ([]byte, error) {
 		return nil, errors.New("no file name given")
 	}
 	if fileSys == nil {
-		return nil, errors.New("no file system given")
+		return nil, errNoFS
 	}
 
 	// if file name does not end with ".star", append it

--- a/run_test.go
+++ b/run_test.go
@@ -1020,6 +1020,13 @@ coins = 50
 			expectedErr: `starlark: exec: cannot load json: module "json" is withheld and not available to this machine`,
 		},
 		{
+			name:        "Unreadable File System keeps original error",
+			lazyMap:     starlet.ModuleLoaderMap{},
+			modFS:       permErrFS{},
+			code:        `load("fib", "fibonacci"); val = fibonacci(10)[-1]`,
+			expectedErr: `starlark: exec: cannot load fib: open fib.star: permission denied`,
+		},
+		{
 			name:        "No FS for Lazyload Modules",
 			lazyMap:     starlet.ModuleLoaderMap{"fib": starlet.MakeModuleLoaderFromFile("fibonacci.star", nil, nil)},
 			code:        `load("fib", "fibonacci"); val = fibonacci(10)[-1]`,

--- a/run_test.go
+++ b/run_test.go
@@ -2160,3 +2160,12 @@ func Test_Machine_Run_LoadTypedErrors(t *testing.T) {
 		t.Errorf("expected ModuleWithheldError{json} via errors.As, got: %v", err)
 	}
 }
+
+// permErrFS fails every Open with a non-NotExist error, exercising the
+// load path that must keep real filesystem errors intact (only "not
+// found anywhere" conditions become typed module errors).
+type permErrFS struct{}
+
+func (permErrFS) Open(name string) (fs.File, error) {
+	return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrPermission}
+}

--- a/run_test.go
+++ b/run_test.go
@@ -215,11 +215,7 @@ func Test_DefaultMachine_Run_LoadNonExist(t *testing.T) {
 	// run
 	_, err := m.Run()
 	// check result
-	if isOnWindows {
-		expectErr(t, err, `starlark: exec: cannot load nonexist.star: open`, `The system cannot find the file specified.`)
-	} else {
-		expectErr(t, err, `starlark: exec: cannot load nonexist.star: open`, `: no such file or directory`)
-	}
+	expectErr(t, err, `starlark: exec: cannot load nonexist.star: module "nonexist.star" not found in builtin modules, custom loaders, or the script filesystem`)
 }
 
 func Test_Machine_Run_Globals(t *testing.T) {
@@ -822,7 +818,7 @@ coins = 50
 		{
 			name:        "No FS for User Modules",
 			code:        `load("fibonacci.star", "fibonacci"); val = fibonacci(10)[-1]`,
-			expectedErr: `starlark: exec: cannot load fibonacci.star: no file system given`,
+			expectedErr: `starlark: exec: cannot load fibonacci.star: module "fibonacci.star" not found`,
 		},
 		{
 			name:        "Missed load() for User Modules",
@@ -840,13 +836,13 @@ coins = 50
 			name:        "NonExist User Modules",
 			code:        `load("nonexist.star", "fibonacci"); val = fibonacci(10)[-1]`,
 			modFS:       testFS,
-			expectedErr: `starlark: exec: cannot load nonexist.star: open`,
+			expectedErr: `starlark: exec: cannot load nonexist.star: module "nonexist.star" not found`,
 		},
 		{
 			name:        "NonExist File System",
 			code:        `load("fibonacci.star", "fibonacci"); val = fibonacci(10)[-1]`,
 			modFS:       nonExistFS,
-			expectedErr: `starlark: exec: cannot load fibonacci.star: open`,
+			expectedErr: `starlark: exec: cannot load fibonacci.star: module "fibonacci.star" not found`,
 		},
 		{
 			name:        "NonExist Function in User Modules",
@@ -1001,21 +997,27 @@ coins = 50
 			name:        "Missing Lazyload Modules",
 			lazyMap:     starlet.ModuleLoaderMap{},
 			code:        `load("fib", "fibonacci"); val = fibonacci(10)[-1]`,
-			expectedErr: `starlark: exec: cannot load fib: no file system given`,
+			expectedErr: `starlark: exec: cannot load fib: module "fib" not found`,
 		},
 		{
 			name:        "Missing Lazyload Modules with Invalid FS",
 			lazyMap:     starlet.ModuleLoaderMap{},
 			modFS:       nonExistFS,
 			code:        `load("fib", "fibonacci"); val = fibonacci(10)[-1]`,
-			expectedErr: `starlark: exec: cannot load fib: open `,
+			expectedErr: `starlark: exec: cannot load fib: module "fib" not found`,
 		},
 		{
 			name:        "Missing Lazyload Modules with Valid FS",
 			lazyMap:     starlet.ModuleLoaderMap{},
 			modFS:       testFS,
 			code:        `load("fib", "fibonacci"); val = fibonacci(10)[-1]`,
-			expectedErr: `starlark: exec: cannot load fib: open `,
+			expectedErr: `starlark: exec: cannot load fib: module "fib" not found`,
+		},
+		{
+			name:        "Disabled Builtin Module is Withheld",
+			lazyMap:     starlet.ModuleLoaderMap{},
+			code:        `load("json", "encode")`,
+			expectedErr: `starlark: exec: cannot load json: module "json" is withheld and not available to this machine`,
 		},
 		{
 			name:        "No FS for Lazyload Modules",
@@ -2137,4 +2139,24 @@ func TestMachine_REPL_Error(t *testing.T) {
 	m := starlet.NewDefault()
 	m.SetGlobals(starlet.StringAnyMap{"x": make(chan int, 1)})
 	m.REPL()
+}
+
+func Test_Machine_Run_LoadTypedErrors(t *testing.T) {
+	// an unknown name surfaces as ModuleNotFoundError through the chain
+	m := starlet.NewDefault()
+	m.SetScript("test.star", []byte(`load("nope", "x")`), nil)
+	_, err := m.Run()
+	var nf starlet.ModuleNotFoundError
+	if err == nil || !errors.As(err, &nf) || nf.Name != "nope" {
+		t.Errorf("expected ModuleNotFoundError{nope} via errors.As, got: %v", err)
+	}
+
+	// a known builtin that is not enabled surfaces as ModuleWithheldError
+	m2 := starlet.NewDefault()
+	m2.SetScript("test.star", []byte(`load("json", "encode")`), nil)
+	_, err = m2.Run()
+	var wh starlet.ModuleWithheldError
+	if err == nil || !errors.As(err, &wh) || wh.Name != "json" {
+		t.Errorf("expected ModuleWithheldError{json} via errors.As, got: %v", err)
+	}
 }


### PR DESCRIPTION
## Why

`load()` of any name missing from the machine's module set fell through to the script-file path, so **a disabled module, a misspelled name, and a genuinely missing file** all surfaced as `cannot load X: no file system given` (or an `open X.star: file does not exist` error) — blaming the filesystem for a module-configuration issue and leaving hosts string-matching to guess the cause (Backlog **LET-15**; every starlet user hits this one).

## What

When the name resolves nowhere (loader miss + no FS / file not found), the load path now reports typed errors:

- `ModuleNotFoundError{Name}` — unknown to builtins, custom loaders, and the script filesystem: `module "fib" not found in builtin modules, custom loaders, or the script filesystem`
- `ModuleWithheldError{Name}` — the name is a **known builtin that was deliberately not enabled** for this machine: `module "json" is withheld and not available to this machine`. Host-side policy layers (L3) can return the same type from their own loaders to mark policy denials.

Both are reachable host-side with `errors.As` through the Starlark error chain (verified on the current pin: `wrappedError` → `EvalError.Unwrap` → `ExecError.Unwrap`) — no string matching needed.

Loader-internal failures keep their original text (e.g. a custom loader explicitly bound to a nil FS still reports `no file system given`, which is accurate **there**).

## Behavior change

Only load()-failure error *text* changes (scripts cannot catch load errors, so script behavior is unchanged); hosts matching the old strings should switch to `errors.As`. Seven test expectations updated accordingly; new cases pin the withheld path and the `errors.As` reachability of both types.

Refs: LET-15

🤖 Generated with [Claude Code](https://claude.com/claude-code)