### PR TITLE
[fix] LET-21: program cache key covers the full compile surface

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 	"sync"
 
 	itn "github.com/1set/starlet/internal"
@@ -24,12 +26,16 @@ func (m *Machine) execStarlarkFile(filename string, src interface{}, allowCache 
 		return starlark.ExecFileOptions(opts, thread, filename, src, predeclared)
 	}
 
-	// for compiled program and cache key
+	// for compiled program and cache key; sources that cannot be
+	// content-keyed (e.g. an io.Reader) are executed without the cache
+	// rather than risking a stale hit on a filename-only key
+	key, ok := m.getCacheKey(src)
+	if !ok {
+		return starlark.ExecFileOptions(opts, thread, filename, src, predeclared)
+	}
 	var (
 		prog *starlark.Program
 		err  error
-		//key = fmt.Sprintf("%d:%s", starlark.CompilerVersion, filename)
-		key = getCacheKey(filename, src)
 	)
 
 	// try to load compiled program from cache first
@@ -65,7 +71,24 @@ func (m *Machine) execStarlarkFile(filename string, src interface{}, allowCache 
 	return g, err
 }
 
-func getCacheKey(filename string, src interface{}) string {
+// getCacheKey derives the cache key for a compiled program. The key must
+// cover everything the compiler consumes, not just the source text:
+//
+//   - the predeclared NAME SET: resolution binds each identifier as
+//     predeclared vs global/undefined via predeclared.Has, so the same
+//     source compiled under a different name set is a different program.
+//     A stale hit either failed at run time with "internal error:
+//     predeclared variable X is uninitialized" or silently validated a
+//     source that must not compile;
+//   - the dialect bits (recursion / global-reassign FileOptions), which
+//     gate parsing and resolution;
+//   - the source content. An io.Reader source used to fall back to a
+//     filename-only key, so identical names with different content
+//     collided — such sources now report ok=false and skip the cache.
+//
+// The key layout is internal and may change between releases; persisted
+// caches then miss once and recompile.
+func (m *Machine) getCacheKey(src interface{}) (key string, ok bool) {
 	var k string
 	switch s := src.(type) {
 	case string:
@@ -73,9 +96,27 @@ func getCacheKey(filename string, src interface{}) string {
 	case []byte:
 		k = itn.GetBytesMD5(s)
 	default:
-		k = filename
+		return "", false
 	}
-	return fmt.Sprintf("%d:%s", starlark.CompilerVersion, k)
+
+	// fold in the sorted predeclared names
+	names := make([]string, 0, len(m.predeclared))
+	for n := range m.predeclared {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	nd := itn.GetStringMD5(strings.Join(names, "\x00"))
+
+	// fold in the dialect bits
+	var opt int
+	if m.allowRecursion {
+		opt |= 1
+	}
+	if m.allowGlobalReassign {
+		opt |= 2
+	}
+
+	return fmt.Sprintf("%d:%d:%s:%s", starlark.CompilerVersion, opt, nd, k), true
 }
 
 // ByteCache is an interface for caching byte data, used for caching compiled Starlark programs.

--- a/exec_test.go
+++ b/exec_test.go
@@ -2,6 +2,7 @@ package starlet_test
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/1set/starlet"
@@ -135,5 +136,72 @@ func BenchmarkRunMemoryCache(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, _ = m.Run()
+	}
+}
+
+func Test_ScriptCache_PredeclaredMismatch(t *testing.T) {
+	src := []byte(`y = x`)
+	cache := starlet.NewMemoryCache()
+
+	// machine A knows the predeclared name x and caches the compiled program
+	ma := starlet.NewWithNames(map[string]interface{}{"x": 1}, nil, nil)
+	ma.SetScriptCache(cache)
+	ma.SetScript("shared.star", src, nil)
+	if _, err := ma.Run(); err != nil {
+		t.Fatalf("machine A expects no error, got: %v", err)
+	}
+
+	// machine B does not know x: it must not reuse A's compiled program —
+	// the stale hit used to surface as "internal error: predeclared
+	// variable x is uninitialized" instead of a clean resolve error
+	mb := starlet.NewDefault()
+	mb.SetScriptCache(cache)
+	mb.SetScript("shared.star", src, nil)
+	if _, err := mb.Run(); err == nil || !strings.Contains(err.Error(), "undefined: x") {
+		t.Errorf("machine B expects 'undefined: x', got: %v", err)
+	}
+}
+
+func Test_ScriptCache_PredeclaredMismatchSilent(t *testing.T) {
+	// the nastier direction: with a stale cache hit this program ran
+	// silently to completion even though it must not compile without x
+	src := []byte("def f():\n    return x\ny = 1\n")
+	cache := starlet.NewMemoryCache()
+
+	ma := starlet.NewWithNames(map[string]interface{}{"x": 1}, nil, nil)
+	ma.SetScriptCache(cache)
+	ma.SetScript("shared.star", src, nil)
+	if _, err := ma.Run(); err != nil {
+		t.Fatalf("machine A expects no error, got: %v", err)
+	}
+
+	mb := starlet.NewDefault()
+	mb.SetScriptCache(cache)
+	mb.SetScript("shared.star", src, nil)
+	if _, err := mb.Run(); err == nil || !strings.Contains(err.Error(), "undefined: x") {
+		t.Errorf("machine B expects 'undefined: x', got: %v", err)
+	}
+}
+
+func Test_ScriptCache_DialectMismatch(t *testing.T) {
+	src := []byte("i = 0\nwhile i < 3:\n    i += 1\n")
+	cache := starlet.NewMemoryCache()
+
+	// machine A compiles the while-dialect program and caches it
+	ma := starlet.NewDefault()
+	ma.EnableGlobalReassign()
+	ma.SetScriptCache(cache)
+	ma.SetScript("shared.star", src, nil)
+	if _, err := ma.Run(); err != nil {
+		t.Fatalf("machine A expects no error, got: %v", err)
+	}
+
+	// machine B has the default dialect: a stale hit used to let the
+	// while-program run, silently bypassing B's own dialect settings
+	mb := starlet.NewDefault()
+	mb.SetScriptCache(cache)
+	mb.SetScript("shared.star", src, nil)
+	if _, err := mb.Run(); err == nil || !strings.Contains(err.Error(), "while") {
+		t.Errorf("machine B expects a while-dialect error, got: %v", err)
 	}
 }

--- a/internal_test.go
+++ b/internal_test.go
@@ -2,6 +2,7 @@ package starlet
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"go.starlark.net/starlark"
@@ -96,5 +97,60 @@ func TestSetOutputConversionEnabled(t *testing.T) {
 	m.SetOutputConversionEnabled(true)
 	if m.enableOutConv != true {
 		t.Errorf("Expected output conversion to be enabled, but it wasn't")
+	}
+}
+
+func TestGetCacheKey(t *testing.T) {
+	m1 := NewDefault()
+	k1, ok := m1.getCacheKey("a = 1")
+	if !ok || k1 == "" {
+		t.Errorf("expected a usable key for a string source, got %q ok=%v", k1, ok)
+	}
+
+	// bytes and string of the same content agree
+	if k, _ := m1.getCacheKey([]byte("a = 1")); k != k1 {
+		t.Errorf("expected the byte and string keys to agree, got %q vs %q", k, k1)
+	}
+
+	// reader-like sources cannot be content-keyed and must skip the cache
+	if _, ok := m1.getCacheKey(strings.NewReader("a = 1")); ok {
+		t.Errorf("expected a reader source to be uncacheable")
+	}
+
+	// a different predeclared name set changes the key
+	m2 := NewDefault()
+	m2.predeclared = starlark.StringDict{"x": starlark.None}
+	if k, _ := m2.getCacheKey("a = 1"); k == k1 {
+		t.Errorf("expected the predeclared name set to be part of the key")
+	}
+
+	// dialect bits change the key
+	m3 := NewDefault()
+	m3.allowRecursion = true
+	if k, _ := m3.getCacheKey("a = 1"); k == k1 {
+		t.Errorf("expected the dialect bits to be part of the key")
+	}
+	m4 := NewDefault()
+	m4.allowGlobalReassign = true
+	if k, _ := m4.getCacheKey("a = 1"); k == k1 {
+		t.Errorf("expected the global-reassign bit to be part of the key")
+	}
+}
+
+func TestExecStarlarkFileUncacheableSource(t *testing.T) {
+	// a source that cannot be content-keyed must execute without touching
+	// the cache instead of risking a stale filename-only hit
+	m := NewDefault()
+	m.SetScriptCacheEnabled(true)
+	m.SetScript("seed.star", []byte("a = 1"), nil)
+	if _, err := m.Run(); err != nil {
+		t.Fatalf("seed run expects no error, got: %v", err)
+	}
+	res, err := m.execStarlarkFile("reader.star", strings.NewReader("zz = 9"), true)
+	if err != nil {
+		t.Fatalf("reader source expects no error, got: %v", err)
+	}
+	if v, ok := res["zz"]; !ok || v.String() != "9" {
+		t.Errorf("expected zz = 9 from the uncached reader source, got: %v", res)
 	}
 }

--- a/machine_test.go
+++ b/machine_test.go
@@ -649,9 +649,12 @@ func TestMachine_SetScriptCache(t *testing.T) {
 		res, err := m.Run()
 		checkRes(701, err, res, 2)
 
-		// NOTICE: cache pollution is possible here if the file content is not used as cache key
+		// a different file with the same name must not hit the cached
+		// program of the first file: the key covers the file content
+		// (the old filename-only key for file sources made this case
+		// return the polluted 2)
 		res, err = m.RunFile("two.star", os.DirFS("testdata/nemo"), nil)
-		checkRes(702, err, res, 2)
+		checkRes(702, err, res, 200)
 
 		m.SetScriptCacheEnabled(false)
 		res, err = m.RunFile("two.star", os.DirFS("testdata"), nil)

--- a/run.go
+++ b/run.go
@@ -3,6 +3,7 @@ package starlet
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/fs"
 	"sync"
 	"time"
@@ -126,12 +127,21 @@ func (m *Machine) runInternal(ctx context.Context, extras StringAnyMap, allowCac
 			// if no name, cannot load
 			return nil, errorStarletErrorf("run", "no script name")
 		}
-		// load script from FS
+		// load the script content from FS, so that the program cache can
+		// key on the content (passing the open reader through degraded the
+		// cache key to the bare filename, letting different files with the
+		// same name hit each other's compiled program) — and the file
+		// handle was never closed
 		rd, e := m.scriptFS.Open(scriptName)
 		if e != nil {
 			return nil, errorStarletError("run", e)
 		}
-		source = rd
+		b, e := io.ReadAll(rd)
+		_ = rd.Close()
+		if e != nil {
+			return nil, errorStarletError("run", e)
+		}
+		source = b
 	} else {
 		return nil, errorStarletErrorf("run", "no script to execute")
 	}


### PR DESCRIPTION
## Why

The compiled-program cache keyed on `CompilerVersion:MD5(source)` only — but compilation also consumes the **predeclared name set** (resolution binds every identifier as predeclared vs global/undefined via `predeclared.Has`) and the **dialect FileOptions** (Backlog **LET-21**, determinism). Machines sharing a `ByteCache` (a supported pattern downstream), or a single machine whose predeclared set grows between runs (results merge back into predeclared), could hit a stale program:

- run-time `internal error: predeclared variable X is uninitialized`, or worse
- a source that must **not** compile ran silently (the undefined reference validated under another machine's larger name set)
- dialect mismatches let `while`-programs run on machines whose dialect forbids them

File-based scripts were worse: the open `fs.File` was passed straight to the compiler, so the key degraded to the **bare filename** — different files with the same name hit each other's compiled programs (machine_test case #702 had actually pinned the polluted result as the expected value, with a NOTICE comment) — and the file handle was never closed.

## What

- Key = `CompilerVersion : dialect-bits : MD5(sorted predeclared names) : MD5(source)`.
- File scripts: content is read once (handle closed), so they get genuine content-keyed caching.
- Sources that cannot be content-keyed skip the cache entirely instead of risking a filename collision.

## Tests

Test-first: three black-box repro cases fail on the old code (cross-machine predeclared mismatch in both directions — loud and **silent** — and a while-dialect bypass); case #702's expectation corrected from the polluted value to the real one; white-box tests pin the key composition (names/dialect/content, byte-vs-string agreement, reader refusal) and the uncached-reader execution path.

## Behavior change

Persisted ByteCache entries miss once after upgrade and recompile (the key layout was never a documented stable surface). `RunFile`/FS-based scripts now close the script file handle.

Refs: LET-21

🤖 Generated with [Claude Code](https://claude.com/claude-code)