### PR TITLE
[feat] LET-24: CallWithContext/CallWithTimeout; fail fast on cancelled contexts

### DIFF
--- a/call.go
+++ b/call.go
@@ -2,13 +2,37 @@ package starlet
 
 import (
 	"context"
+	"time"
 
 	"github.com/1set/starlight/convert"
 	"go.starlark.net/starlark"
 )
 
 // Call executes a Starlark function or builtin saved in the thread and returns the result.
+// The function runs without a context: it cannot be cancelled or time-bounded;
+// use CallWithContext or CallWithTimeout for that.
 func (m *Machine) Call(name string, args ...interface{}) (out interface{}, err error) {
+	return m.callInternal(nil, name, args)
+}
+
+// CallWithTimeout executes like Call, but the function call (and any
+// context-aware library builtin it invokes) is aborted once the timeout
+// elapses, matching RunWithTimeout semantics.
+func (m *Machine) CallWithTimeout(timeout time.Duration, name string, args ...interface{}) (out interface{}, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return m.callInternal(ctx, name, args)
+}
+
+// CallWithContext executes like Call, but the function call (and any
+// context-aware library builtin it invokes) is aborted when ctx is
+// cancelled, matching RunWithContext semantics. A nil context behaves like
+// plain Call; an already-cancelled context fails immediately.
+func (m *Machine) CallWithContext(ctx context.Context, name string, args ...interface{}) (out interface{}, err error) {
+	return m.callInternal(ctx, name, args)
+}
+
+func (m *Machine) callInternal(ctx context.Context, name string, args []interface{}) (out interface{}, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -46,9 +70,21 @@ func (m *Machine) Call(name string, args ...interface{}) (out interface{}, err e
 		sl = append(sl, sv)
 	}
 
-	// reset thread
+	// reset the thread and wire the context
 	m.thread.Uncancel()
-	m.thread.SetLocal("context", context.TODO())
+	if ctx == nil {
+		// plain Call: no cancellation channel, as before
+		m.thread.SetLocal("context", context.TODO())
+	} else {
+		if err := ctx.Err(); err != nil {
+			// fail fast instead of silently calling with a context that
+			// can never fire again
+			return nil, errorStarletError("call", err)
+		}
+		m.thread.SetLocal("context", ctx)
+		stop := m.watchContextCancel(ctx)
+		defer stop()
+	}
 
 	// call and convert result
 	res, err := starlark.Call(m.thread, callFunc, sl, nil)

--- a/call_test.go
+++ b/call_test.go
@@ -1,10 +1,13 @@
 package starlet_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/1set/starlet"
 	"go.starlark.net/starlark"
@@ -247,5 +250,60 @@ def work(x, y):
 		return
 	} else if v != starlark.MakeInt(30) {
 		t.Errorf("got unexpected value: %v", v)
+	}
+}
+
+func TestMachine_CallWithContext(t *testing.T) {
+	prep := func() *starlet.Machine {
+		m := starlet.NewWithNames(nil, []string{"go_idiomatic"}, nil)
+		m.SetScript("test.star", []byte("def slow():\n    sleep(2)\n    return 1\n\ndef quick(x):\n    return x + 1\n"), nil)
+		if _, err := m.Run(); err != nil {
+			t.Fatalf("prep run expects no error, got: %v", err)
+		}
+		return m
+	}
+
+	// the timeout aborts the call long before the function finishes
+	{
+		m := prep()
+		ts := time.Now()
+		_, err := m.CallWithTimeout(200*time.Millisecond, "slow")
+		if err == nil || !strings.Contains(err.Error(), "context") {
+			t.Errorf("expected a context error from the timed-out call, got: %v", err)
+		}
+		if elapsed := time.Since(ts); elapsed > time.Second {
+			t.Errorf("call was not aborted in time: %v", elapsed)
+		}
+	}
+
+	// an already-cancelled context fails immediately
+	{
+		m := prep()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := m.CallWithContext(ctx, "quick", 1)
+		if err == nil || !strings.Contains(err.Error(), "starlet: call: context canceled") {
+			t.Errorf("expected fail-fast on a cancelled context, got: %v", err)
+		}
+	}
+
+	// a nil context behaves like plain Call
+	{
+		m := prep()
+		out, err := m.CallWithContext(nil, "quick", 41)
+		if err != nil || out != int64(42) {
+			t.Errorf("expected 42 with no error, got: %v / %v", out, err)
+		}
+	}
+
+	// a live context lets the call complete
+	{
+		m := prep()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		out, err := m.CallWithContext(ctx, "quick", 1)
+		if err != nil || out != int64(2) {
+			t.Errorf("expected 2 with no error, got: %v / %v", out, err)
+		}
 	}
 }

--- a/run.go
+++ b/run.go
@@ -103,6 +103,32 @@ func (m *Machine) RunWithContext(ctx context.Context, extras StringAnyMap) (Stri
 	return m.runInternal(ctx, extras, true)
 }
 
+// watchContextCancel cancels the machine's thread when ctx fires, until the
+// returned stop function is called. stop is idempotent and waits for the
+// watcher goroutine to exit, so callers can both defer it (panic safety)
+// and invoke it right after execution finishes.
+func (m *Machine) watchContextCancel(ctx context.Context) (stop func()) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	done := make(chan struct{})
+	go func() {
+		defer wg.Done()
+		select {
+		case <-ctx.Done():
+			m.thread.Cancel("context cancelled")
+		case <-done:
+			// no action if execution has finished
+		}
+	}()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			close(done)
+			wg.Wait()
+		})
+	}
+}
+
 func (m *Machine) runInternal(ctx context.Context, extras StringAnyMap, allowCache bool) (out StringAnyMap, err error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -152,35 +178,25 @@ func (m *Machine) runInternal(ctx context.Context, extras StringAnyMap, allowCac
 	}
 
 	// cancel thread when context cancelled
-	if ctx == nil || ctx.Err() != nil {
-		// for nil context, or context already cancelled, use a new one
+	if ctx == nil {
+		// no context given: use an inert placeholder
 		ctx = context.TODO()
+	} else if e := ctx.Err(); e != nil {
+		// an already-cancelled context used to be silently replaced with an
+		// uncancellable one, running the script with no deadline at all —
+		// fail fast instead
+		return nil, errorStarletError("run", e)
 	}
 	m.thread.SetLocal("context", ctx)
 
-	// wait for the routine to finish, or cancel it when context cancelled
-	var wg sync.WaitGroup
-	defer wg.Wait()
-	wg.Add(1)
-
-	// if context is not cancelled, cancel the routine when execution is done, or panic
-	done := make(chan struct{}, 1)
-	defer close(done)
-
-	go func() {
-		defer wg.Done()
-		select {
-		case <-ctx.Done():
-			m.thread.Cancel("context cancelled")
-		case <-done:
-			// No action if the script has finished
-		}
-	}()
+	// cancel the thread when the context fires, until execution finishes
+	stop := m.watchContextCancel(ctx)
+	defer stop()
 
 	// run with everything prepared
 	m.runTimes++
 	res, err := m.execStarlarkFile(scriptName, source, allowCache)
-	done <- struct{}{}
+	stop()
 
 	// merge result as predeclared for next run
 	for k, v := range res {

--- a/run_test.go
+++ b/run_test.go
@@ -1575,20 +1575,12 @@ func Test_Machine_Run_With_CancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	// run script
+	// run script: an already-cancelled context fails fast instead of being
+	// silently replaced with an uncancellable one (the old behavior ran the
+	// script with no deadline at all)
 	m.SetScript("timer.star", []byte(`a = 1; b = 2`), nil)
-	out, err := m.RunWithContext(ctx, nil)
-	if err != nil {
-		t.Errorf("Expected no errors, got error: %v", err)
-		return
-	}
-	if out == nil {
-		t.Errorf("Unexpected empty result: %v", out)
-	} else if len(out) != 2 {
-		t.Errorf("Unexpected result: %v", out)
-	} else {
-		t.Logf("got result after run: %v", out)
-	}
+	_, err := m.RunWithContext(ctx, nil)
+	expectErr(t, err, `starlet: run: context canceled`)
 }
 
 func Test_Machine_Run_With_Context(t *testing.T) {


### PR DESCRIPTION
## Why

`Machine.Call` reset the thread with `context.TODO()` and ran without a cancellation watcher (Backlog **LET-24**): a function invoked through Call — and every context-aware library builtin it used (`sleep`, `net`, `http`) — could not be cancelled or time-bounded, inconsistent with `Run`/`RunWithTimeout`/`RunWithContext`. Worse: Call holds `m.mu` for its whole duration, so `GetStarlarkThread()` blocks mid-call — there wasn't even a manual-Cancel escape hatch.

## What

- **`CallWithContext(ctx, name, args...)`** and **`CallWithTimeout(d, name, args...)`**: wire the context into the thread and cancel it when the context fires, exactly like the Run family. Plain `Call` is byte-for-byte unchanged (nil context). A variadic ctx-sniffing overload was deliberately rejected — `args` is `...interface{}`, so sniffing would silently change behavior for callers passing a context as a real argument.
- The context watcher is extracted into a shared helper used by both Run and Call paths (idempotent stop; panic-safe via defer).
- **Fail fast on already-cancelled contexts**: `runInternal` silently swapped a cancelled context for an uncancellable `TODO` one — the script then ran with *no deadline at all*. `RunWithContext`/`CallWithContext` now return `context canceled` immediately.

## Behavior change

`RunWithContext(cancelledCtx)` errors immediately instead of running unbounded (the old behavior was pinned by `Test_Machine_Run_With_CancelledContext`, which is updated — passing an already-dead context and expecting an un-deadlined run is the footgun this fixes).

Tests: timeout aborts a sleeping function in well under its duration; cancelled-context fail-fast on both paths; nil-context parity with Call; live-context completion.

Refs: LET-24

🤖 Generated with [Claude Code](https://claude.com/claude-code)