### PR TITLE
[feat] LET-16: Machine.SetMaxExecutionSteps — a CPU budget for untrusted scripts

### DIFF
--- a/call.go
+++ b/call.go
@@ -38,7 +38,11 @@ func (m *Machine) callInternal(ctx context.Context, name string, args []interfac
 
 	defer func() {
 		if r := recover(); r != nil {
-			err = errorStarlarkPanic("call", r)
+			if me, ok := r.(MaxStepsExceededError); ok {
+				err = errorStarlarkError("call", me)
+			} else {
+				err = errorStarlarkPanic("call", r)
+			}
 		}
 	}()
 
@@ -70,8 +74,9 @@ func (m *Machine) callInternal(ctx context.Context, name string, args []interfac
 		sl = append(sl, sv)
 	}
 
-	// reset the thread and wire the context
+	// reset the thread, arm the step budget, and wire the context
 	m.thread.Uncancel()
+	m.applyStepBudget()
 	if ctx == nil {
 		// plain Call: no cancellation channel, as before
 		m.thread.SetLocal("context", context.TODO())

--- a/error.go
+++ b/error.go
@@ -121,3 +121,15 @@ type ModuleWithheldError struct {
 func (e ModuleWithheldError) Error() string {
 	return fmt.Sprintf("module %q is withheld and not available to this machine", e.Name)
 }
+
+// MaxStepsExceededError marks an execution aborted because it exhausted the
+// step budget configured with Machine.SetMaxExecutionSteps. Detect it with
+// errors.As through the execution error chain.
+type MaxStepsExceededError struct {
+	Limit uint64
+}
+
+// Error returns the error message.
+func (e MaxStepsExceededError) Error() string {
+	return fmt.Sprintf("execution exceeded the step limit (%d)", e.Limit)
+}

--- a/machine.go
+++ b/machine.go
@@ -44,6 +44,7 @@ type Machine struct {
 	enableInConv        bool
 	enableOutConv       bool
 	customTag           string
+	maxSteps            uint64
 	// source code
 	scriptName    string
 	scriptContent []byte
@@ -330,6 +331,19 @@ func (m *Machine) Export() StringAnyMap {
 	defer m.mu.RUnlock()
 
 	return m.convertOutput(m.predeclared)
+}
+
+// SetMaxExecutionSteps sets the per-execution budget of Starlark steps (an
+// abstract measure of interpreter work); 0 (the default) means unlimited.
+// When the budget is exhausted, the Run or Call fails with a
+// MaxStepsExceededError, reachable host-side via errors.As. The step
+// counter resets at the start of every Run/Call, so the budget applies per
+// execution, not cumulatively.
+func (m *Machine) SetMaxExecutionSteps(steps uint64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.maxSteps = steps
 }
 
 // EnableRecursionSupport enables recursion support in all Starlark environments.

--- a/machine_test.go
+++ b/machine_test.go
@@ -795,3 +795,76 @@ func TestMachine_GetThreadLocal(t *testing.T) {
 		t.Errorf("expected 'Deeper', got %v", v)
 	}
 }
+
+func TestMachine_SetMaxExecutionSteps(t *testing.T) {
+	loopScript := []byte("def burn():\n    x = 0\n    for i in range(10000):\n        x += 1\n    return x\nr = burn()\n")
+
+	// the budget trips and surfaces as a typed error
+	{
+		m := starlet.NewDefault()
+		m.SetMaxExecutionSteps(100)
+		m.SetScript("loop.star", loopScript, nil)
+		_, err := m.Run()
+		var me starlet.MaxStepsExceededError
+		if err == nil || !errors.As(err, &me) || me.Limit != 100 {
+			t.Errorf("expected MaxStepsExceededError{100}, got: %v", err)
+		}
+	}
+
+	// zero (the default) means unlimited
+	{
+		m := starlet.NewDefault()
+		m.SetScript("loop.star", loopScript, nil)
+		if _, err := m.Run(); err != nil {
+			t.Errorf("expected the unlimited run to pass, got: %v", err)
+		}
+	}
+
+	// clearing the budget on a REUSED thread must mean unlimited again:
+	// the runtime normalizes 0 to "unlimited" only on a thread's first
+	// use, so a literal 0 would trip on the very first step
+	{
+		m := starlet.NewDefault()
+		m.SetMaxExecutionSteps(100)
+		m.SetScript("loop.star", loopScript, nil)
+		if _, err := m.Run(); err == nil {
+			t.Errorf("expected the budget to trip on the first run")
+		}
+		m.SetMaxExecutionSteps(0)
+		if _, err := m.Run(); err != nil {
+			t.Errorf("expected the unlimited rerun to pass, got: %v", err)
+		}
+	}
+
+	// the step counter resets per run instead of accumulating
+	{
+		m := starlet.NewDefault()
+		m.SetScript("small.star", []byte("y = 1 + 1"), nil)
+		if _, err := m.Run(); err != nil {
+			t.Fatalf("run #1 expects no error, got: %v", err)
+		}
+		s1 := m.GetStarlarkThread().Steps
+		if _, err := m.Run(); err != nil {
+			t.Fatalf("run #2 expects no error, got: %v", err)
+		}
+		s2 := m.GetStarlarkThread().Steps
+		if s1 == 0 || s1 != s2 {
+			t.Errorf("expected matching per-run step counts, got %d then %d", s1, s2)
+		}
+	}
+
+	// the budget guards Call the same way as Run
+	{
+		m := starlet.NewDefault()
+		m.SetScript("def.star", []byte("def loop():\n    x = 0\n    for i in range(10000):\n        x += 1\n    return x\n"), nil)
+		if _, err := m.Run(); err != nil {
+			t.Fatalf("prep run expects no error, got: %v", err)
+		}
+		m.SetMaxExecutionSteps(100)
+		_, err := m.Call("loop")
+		var me starlet.MaxStepsExceededError
+		if err == nil || !errors.As(err, &me) || me.Limit != 100 {
+			t.Errorf("expected MaxStepsExceededError{100} from Call, got: %v", err)
+		}
+	}
+}

--- a/run.go
+++ b/run.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math"
 	"sync"
 	"time"
 
@@ -132,7 +133,11 @@ func (m *Machine) watchContextCancel(ctx context.Context) (stop func()) {
 func (m *Machine) runInternal(ctx context.Context, extras StringAnyMap, allowCache bool) (out StringAnyMap, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = errorStarlarkPanic("exec", r)
+			if me, ok := r.(MaxStepsExceededError); ok {
+				err = errorStarlarkError("exec", me)
+			} else {
+				err = errorStarlarkPanic("exec", r)
+			}
 		}
 	}()
 
@@ -298,7 +303,32 @@ func (m *Machine) prepareThread(extras StringAnyMap) (err error) {
 		m.thread.Print = m.printFunc
 		m.thread.Uncancel()
 	}
+
+	// arm the per-run step budget
+	m.applyStepBudget()
 	return nil
+}
+
+// applyStepBudget arms the thread with the configured step budget; it must
+// run before every execution. The Starlark runtime normalizes a zero limit
+// to "unlimited" only on a thread's very first use, so the translation to
+// MaxUint64 happens here for reused threads; the step counter resets so
+// the budget applies per execution.
+func (m *Machine) applyStepBudget() {
+	limit := m.maxSteps
+	if limit == 0 {
+		limit = math.MaxUint64
+	}
+	m.thread.SetMaxExecutionSteps(limit)
+	if lim := m.maxSteps; lim > 0 {
+		m.thread.OnMaxSteps = func(*starlark.Thread) {
+			// recovered by the run/call recover and mapped to a typed error
+			panic(MaxStepsExceededError{Limit: lim})
+		}
+	} else {
+		m.thread.OnMaxSteps = nil
+	}
+	m.thread.Steps = 0
 }
 
 // Reset resets the machine to initial state before the first run.


### PR DESCRIPTION
## Why

starlet exposed no step-limit entry point even though the underlying runtime has had `Thread.SetMaxExecutionSteps`/`OnMaxSteps` since well before the current pin (Backlog **LET-16**): a tight compute loop in an untrusted script could only be stopped by wall-clock timeout — and the `Call` path (before #138) not even by that. A step budget is the standard answer to runaway loops; wall-clock is the wrong tool on busy hosts.

## What

- **`SetMaxExecutionSteps(n)`**: per-execution step budget, `0` = unlimited (default, zero behavior change). Armed by `prepareThread` (Run family) and `callInternal` (Call family), so a budget set between runs applies to the next execution.
- **Two runtime traps handled** (both verified against the pinned source):
  1. the zero→unlimited normalization happens only on a thread's **first** use — a literal 0 on a reused thread trips on the very first step, so 0 is translated to `MaxUint64` when arming;
  2. `thread.Steps` accumulates across runs — the counter resets per execution, so the budget is **per run, not cumulative** (`Machine.String()`'s step count now reports the current execution; documented on the setter).
- Exhaustion surfaces as **`MaxStepsExceededError{Limit}`**, reachable with `errors.As` on both Run and Call paths (`OnMaxSteps` panics with the typed value, the existing recover maps it) — same typed-error contract as #136's load errors, no string matching.

No pin-upgrade dependency: both runtime primitives exist at the current pin.

Tests: budget trips with the typed error (Run and Call); default unlimited; **0-after-nonzero on a reused thread** (the normalization trap); per-run counter reset pinned via equal step counts across runs.

Refs: LET-16

🤖 Generated with [Claude Code](https://claude.com/claude-code)