### PR TITLE
[fix] LET-14: httping honors the system proxy; add the missing lib/net README

### DIFF
--- a/lib/net/README.md
+++ b/lib/net/README.md
@@ -10,8 +10,6 @@ All three functions honor the machine's context: a `RunWithTimeout`/`RunWithCont
 
 Looks up the IP addresses of a domain name, returning a list of strings.
 
-#### Parameters
-
 | name         | type     | description                                                                                                                                                                      |
 |--------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `domain`     | `string` | the domain name to resolve (an IP literal is returned as-is)                                                                                                                    |
@@ -21,8 +19,6 @@ Looks up the IP addresses of a domain name, returning a list of strings.
 ### `tcping(hostname, port=80, count=4, timeout=10, interval=1) statistics`
 
 Measures TCP connect round-trip times to `hostname:port` and returns a `statistics` struct.
-
-#### Parameters
 
 | name       | type        | description                                                              |
 |------------|-------------|--------------------------------------------------------------------------|

--- a/lib/net/README.md
+++ b/lib/net/README.md
@@ -1,0 +1,53 @@
+# net
+
+`net` provides network diagnostics for Starlark: DNS lookup, TCP ping, and HTTP ping. It is inspired by Go's `net` package and Python's `socket` module.
+
+All three functions honor the machine's context: a `RunWithTimeout`/`RunWithContext` deadline aborts a lookup or an in-flight ping loop promptly.
+
+## Functions
+
+### `nslookup(domain, dns_server=None, timeout=10) []string`
+
+Looks up the IP addresses of a domain name, returning a list of strings.
+
+#### Parameters
+
+| name         | type     | description                                                                                                                                                                      |
+|--------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `domain`     | `string` | the domain name to resolve (an IP literal is returned as-is)                                                                                                                    |
+| `dns_server` | `string` | optional DNS server as `host` or `host:port` (port defaults to 53). Uses the system resolver when omitted. NOTE: a custom server requires the pure-Go resolver, which is a no-op on Windows before Go 1.19 — the system resolver is used there instead. |
+| `timeout`    | `float/int` | lookup timeout in seconds; non-positive values fall back to 10                                                                                                                |
+
+### `tcping(hostname, port=80, count=4, timeout=10, interval=1) statistics`
+
+Measures TCP connect round-trip times to `hostname:port` and returns a `statistics` struct.
+
+#### Parameters
+
+| name       | type        | description                                                              |
+|------------|-------------|--------------------------------------------------------------------------|
+| `hostname` | `string`    | the host to ping (resolved first; an IP literal skips DNS)               |
+| `port`     | `int`       | TCP port, defaults to 80                                                 |
+| `count`    | `int`       | number of rounds, `1..1024`                                              |
+| `timeout`  | `float/int` | per-connect timeout in seconds (sub-second values work); at most 3600    |
+| `interval` | `float/int` | pause between rounds in seconds (sub-second values work); at most 3600   |
+
+### `httping(url, count=4, timeout=10, interval=1) statistics`
+
+Measures HTTP connect round-trip times by issuing GET requests to `url` (redirects are not followed; a status outside `200..399` counts as a failed round) and returns a `statistics` struct.
+
+Takes the same `count`/`timeout`/`interval` parameters and bounds as `tcping`. The client honors the system proxy settings (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`), just like `lib/http`; behind a proxy, the measured connect duration is the TCP connection to the proxy (the first hop), not to the origin server.
+
+## Types
+
+### `statistics`
+
+| member    | type     | description                                  |
+|-----------|----------|----------------------------------------------|
+| `address` | `string` | the resolved address or URL that was pinged  |
+| `total`   | `int`    | rounds attempted                             |
+| `success` | `int`    | rounds that succeeded                        |
+| `loss`    | `float`  | failed percentage (0–100)                    |
+| `min`/`avg`/`max`/`stddev` | `float` | round-trip statistics in milliseconds |
+
+If no round succeeds, the function reports a `no successful connections` error instead of returning a struct.

--- a/lib/net/net_internal_test.go
+++ b/lib/net/net_internal_test.go
@@ -1,0 +1,20 @@
+package net
+
+import (
+	"testing"
+)
+
+// White-box checks of internals that the script-level tests cannot reach.
+
+// TestNewPingTransport pins that httping's transport inherits the default
+// transport's settings — most importantly the system proxy hook — instead
+// of a zero-value Transport that never consults a proxy (LET-14).
+func TestNewPingTransport(t *testing.T) {
+	tr := newPingTransport()
+	if tr.Proxy == nil {
+		t.Errorf("expected the ping transport to inherit the system proxy hook")
+	}
+	if !tr.DisableKeepAlives {
+		t.Errorf("expected keep-alives to stay disabled for ping clients")
+	}
+}

--- a/lib/net/net_internal_test.go
+++ b/lib/net/net_internal_test.go
@@ -1,6 +1,7 @@
 package net
 
 import (
+	"net/http"
 	"testing"
 )
 
@@ -16,5 +17,25 @@ func TestNewPingTransport(t *testing.T) {
 	}
 	if !tr.DisableKeepAlives {
 		t.Errorf("expected keep-alives to stay disabled for ping clients")
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// TestNewPingTransportFallback pins the fallback used when the host has
+// replaced http.DefaultTransport with a custom RoundTripper.
+func TestNewPingTransportFallback(t *testing.T) {
+	orig := http.DefaultTransport
+	defer func() { http.DefaultTransport = orig }()
+	http.DefaultTransport = roundTripperFunc(func(r *http.Request) (*http.Response, error) { return nil, nil })
+
+	tr := newPingTransport()
+	if tr.Proxy == nil {
+		t.Errorf("expected the fallback transport to keep the system proxy hook")
+	}
+	if !tr.DisableKeepAlives {
+		t.Errorf("expected keep-alives to stay disabled in the fallback transport")
 	}
 }

--- a/lib/net/ping.go
+++ b/lib/net/ping.go
@@ -94,15 +94,15 @@ func httpPingFunc(ctx context.Context, url string, timeout time.Duration) (time.
 		},
 	}
 
-	// create a http client with timeout and tracing
+	// create a http client with timeout and tracing.
+	// NOTE: behind a proxy, the traced connect duration measures the TCP
+	// connection to the proxy (the first hop), not to the origin server.
 	client := &http.Client{
 		Timeout: timeout,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse // do not follow redirects
 		},
-		Transport: &http.Transport{
-			DisableKeepAlives: true,
-		},
+		Transport: newPingTransport(),
 	}
 	req, err := http.NewRequestWithContext(httptrace.WithClientTrace(ctx, trace), "GET", url, nil)
 	if err != nil {
@@ -141,6 +141,18 @@ func pingDurations(b *starlark.Builtin, timeout, interval tps.FloatOrInt) (timeo
 	timeoutDur = time.Duration(float64(timeout) * float64(time.Second))
 	intervalDur = time.Duration(float64(interval) * float64(time.Second))
 	return timeoutDur, intervalDur, nil
+}
+
+// newPingTransport returns the transport used by httping: a clone of the
+// default transport (so the system proxy settings - HTTP_PROXY etc. -
+// apply, exactly as they do for lib/http) with keep-alives disabled. The
+// zero-value Transport used before never consulted any proxy, so httping
+// failed entirely in forced-egress-proxy environments while http.get in
+// the same script worked.
+func newPingTransport() *http.Transport {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.DisableKeepAlives = true
+	return tr
 }
 
 func createPingStats(address string, count int, rtts []time.Duration) starlark.Value {

--- a/lib/net/ping.go
+++ b/lib/net/ping.go
@@ -150,9 +150,18 @@ func pingDurations(b *starlark.Builtin, timeout, interval tps.FloatOrInt) (timeo
 // failed entirely in forced-egress-proxy environments while http.get in
 // the same script worked.
 func newPingTransport() *http.Transport {
-	tr := http.DefaultTransport.(*http.Transport).Clone()
-	tr.DisableKeepAlives = true
-	return tr
+	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+		tr := dt.Clone()
+		tr.DisableKeepAlives = true
+		return tr
+	}
+	// the default transport was replaced by the host with a custom
+	// RoundTripper: fall back to a fresh transport that still honors the
+	// system proxy settings
+	return &http.Transport{
+		Proxy:             http.ProxyFromEnvironment,
+		DisableKeepAlives: true,
+	}
 }
 
 func createPingStats(address string, count int, rtts []time.Duration) starlark.Value {


### PR DESCRIPTION
## Why

`httping` built its client on a zero-value `http.Transport`, which never consults any proxy (Backlog **LET-14**): in forced-egress-proxy environments every round failed with `no successful connections` while `http.get` **in the same script** worked fine — `lib/http` uses the default transport, so the two modules disagreed about the network.

## What

The transport is now a clone of `http.DefaultTransport` (system proxy via `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY`, plus its sane dial/TLS timeouts) with keep-alives kept off — the same form `lib/http` uses. Extracted as `newPingTransport` and pinned by a white-box test; an env-based test would be unreliable because `ProxyFromEnvironment` caches the environment process-wide on first use.

Behind a proxy, the traced connect duration measures the **first hop** (to the proxy), not the origin — documented in code and in the new README. `lib/net` was the only module without a README; it now documents all three functions, the new LET-13 bounds, and the context-cancellation behavior.

`tcping` still dials directly (an HTTP proxy doesn't apply to raw TCP) — the asymmetry is inherent and documented.

Refs: LET-14

🤖 Generated with [Claude Code](https://claude.com/claude-code)