### PR TITLE
[fix] LET-10: http timeout is per module instance; lock the config reads; reject ignored args

### DIFF
--- a/lib/http/README.md
+++ b/lib/http/README.md
@@ -170,7 +170,7 @@ Perform an HTTP OPTIONS request, returning a response.
 
 ### `set_timeout(timeout)`
 
-Set the global timeout for all HTTP requests.
+Set the default timeout for HTTP requests made through this module instance (i.e. this machine). It does not affect other machines in the process; the package-level `TimeoutSecond` variable seeds new instances. With a host-injected client the value is ignored (the client's own timeout applies).
 
 #### Parameters
 
@@ -180,7 +180,7 @@ Set the global timeout for all HTTP requests.
 
 ### `get_timeout() float`
 
-Get the current global timeout setting for HTTP requests.
+Get the current default timeout of this module instance.
 returns:
 The current timeout in seconds used for HTTP requests.
 

--- a/lib/http/http.go
+++ b/lib/http/http.go
@@ -56,13 +56,20 @@ func LoadModule() (starlark.StringDict, error) {
 
 // Module defines the actual HTTP module with methods for making requests.
 type Module struct {
-	cli *http.Client
-	rg  RequestGuard
+	cli        *http.Client
+	rg         RequestGuard
+	mu         sync.RWMutex
+	timeoutSec float64
 }
 
-// NewModule creates a new http module with default settings.
+// NewModule creates a new http module with default settings. The package
+// level knobs (TimeoutSecond, Client, Guard) seed the new instance; later
+// changes through set_timeout stay within the instance instead of mutating
+// process-wide state shared by every machine.
 func NewModule() *Module {
-	m := &Module{}
+	ConfigLock.RLock()
+	defer ConfigLock.RUnlock()
+	m := &Module{timeoutSec: TimeoutSecond}
 	if Client != nil {
 		m.cli = Client
 	}
@@ -70,6 +77,13 @@ func NewModule() *Module {
 		m.rg = Guard
 	}
 	return m
+}
+
+// defaultTimeout returns the instance's default request timeout in seconds.
+func (m *Module) defaultTimeout() float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.timeoutSec
 }
 
 // SetClient sets the http client for this module, useful for setting custom clients for testing or multiple loadings.
@@ -105,13 +119,15 @@ func (m *Module) StringDict() starlark.StringDict {
 		sd[name] = starlark.NewBuiltin(ModuleName+"."+name, m.reqMethod(name))
 	}
 	sd["call"] = starlark.NewBuiltin(ModuleName+".call", m.callMethod)
-	sd["set_timeout"] = starlark.NewBuiltin(ModuleName+".set_timeout", setRequestTimeout)
-	sd["get_timeout"] = starlark.NewBuiltin(ModuleName+".get_timeout", getRequestTimeout)
+	sd["set_timeout"] = starlark.NewBuiltin(ModuleName+".set_timeout", m.setRequestTimeout)
+	sd["get_timeout"] = starlark.NewBuiltin(ModuleName+".get_timeout", m.getRequestTimeout)
 	return sd
 }
 
-// setRequestTimeout sets the timeout for http requests
-func setRequestTimeout(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+// setRequestTimeout sets the default timeout for this module instance.
+// It used to write the package-level TimeoutSecond, so one script's
+// set_timeout leaked into every machine in the process.
+func (m *Module) setRequestTimeout(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var timeout types.FloatOrInt
 	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "timeout", &timeout); err != nil {
 		return nil, err
@@ -119,22 +135,19 @@ func setRequestTimeout(thread *starlark.Thread, b *starlark.Builtin, args starla
 	if timeout < 0 {
 		return nil, fmt.Errorf("%s: timeout must be non-negative", b.Name())
 	}
-	// update the global TimeoutSecond variable which influences all future HTTP requests.
-	ConfigLock.Lock()
-	defer ConfigLock.Unlock()
-	TimeoutSecond = float64(timeout)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.timeoutSec = float64(timeout)
 	return starlark.None, nil
 }
 
-// getRequestTimeout returns the current timeout for http requests
-func getRequestTimeout(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+// getRequestTimeout returns the current default timeout of this module instance.
+func (m *Module) getRequestTimeout(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	// check the arguments: no arguments
 	if err := starlark.UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	ConfigLock.RLock()
-	defer ConfigLock.RUnlock()
-	return starlark.Float(TimeoutSecond), nil
+	return starlark.Float(m.defaultTimeout()), nil
 }
 
 // callMethod is a general function for making http requests which takes the method name and arguments.
@@ -160,6 +173,13 @@ func (m *Module) callMethod(thread *starlark.Thread, b *starlark.Builtin, args s
 // reqMethod is a factory function for generating starlark builtin functions for different http request methods
 func (m *Module) reqMethod(method string) func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	return func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		// snapshot the defaults: the timeout from the module instance, the
+		// rest from the package knobs under the config lock (these reads
+		// used to be unlocked, racing with concurrent writers)
+		ConfigLock.RLock()
+		defaultRedirect := !DisableRedirect
+		defaultVerify := !SkipInsecureVerify
+		ConfigLock.RUnlock()
 		var (
 			getDefaultDict = func() *types.NullableDict { return types.NewNullableDict(starlark.NewDict(0)) }
 			urlv           starlark.String
@@ -170,14 +190,22 @@ func (m *Module) reqMethod(method string) func(thread *starlark.Thread, b *starl
 			jsonBody       starlark.Value                       // default None, expect JSON serializable object
 			formBody       = getDefaultDict()                   // default None, expect Dict
 			formEncoding   starlark.String                      // default empty string, expect string
-			timeout        = types.FloatOrInt(TimeoutSecond)
-			allowRedirect  = starlark.Bool(!DisableRedirect)
-			verifySSL      = starlark.Bool(!SkipInsecureVerify)
+			timeout        = types.FloatOrInt(m.defaultTimeout())
+			allowRedirect  = starlark.Bool(defaultRedirect)
+			verifySSL      = starlark.Bool(defaultVerify)
 		)
 
 		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "url", &urlv, "params?", params, "headers", headers, "body", body, "json_body", &jsonBody, "form_body", formBody, "form_encoding", &formEncoding,
 			"auth?", &auth, "timeout?", &timeout, "allow_redirects?", &allowRedirect, "verify?", &verifySSL); err != nil {
 			return nil, err
+		}
+
+		// with a host-injected client, per-request transport options cannot
+		// be applied; reject explicit ones instead of silently dropping them
+		if m.cli != nil {
+			if name := findTransportArg(args, kwargs); name != "" {
+				return nil, fmt.Errorf("%s: %s conflicts with the http client provided by the host and would be ignored", b.Name(), name)
+			}
 		}
 
 		rawURL, err := AsString(urlv)
@@ -224,6 +252,29 @@ func (m *Module) reqMethod(method string) func(thread *starlark.Thread, b *starl
 		r := &Response{*res}
 		return r.Struct(), nil
 	}
+}
+
+// findTransportArg reports which of the transport-affecting parameters
+// (timeout, allow_redirects, verify) the caller passed explicitly, either
+// by keyword or positionally (they sit at positions 9..11).
+func findTransportArg(args starlark.Tuple, kwargs []starlark.Tuple) string {
+	switch {
+	case len(args) > 10:
+		return "verify"
+	case len(args) > 9:
+		return "allow_redirects"
+	case len(args) > 8:
+		return "timeout"
+	}
+	for _, kv := range kwargs {
+		if n, ok := starlark.AsString(kv[0]); ok {
+			switch n {
+			case "timeout", "allow_redirects", "verify":
+				return n
+			}
+		}
+	}
+	return ""
 }
 
 func (m *Module) getHTTPClient(timeoutSec float64, allowRedirect, verifySSL bool) *http.Client {
@@ -349,8 +400,11 @@ func setHeaders(req *http.Request, headers *starlark.Dict) error {
 		}
 	}
 
-	if UserAgent != "" && !isUASet {
-		req.Header.Set(UAKey, UserAgent)
+	ConfigLock.RLock()
+	ua := UserAgent
+	ConfigLock.RUnlock()
+	if ua != "" && !isUASet {
+		req.Header.Set(UAKey, ua)
 	}
 	return nil
 }

--- a/lib/http/http_test.go
+++ b/lib/http/http_test.go
@@ -771,3 +771,69 @@ func TestLoadModule_CustomLoad(t *testing.T) {
 		})
 	}
 }
+
+func TestModuleTimeoutInstanceScope(t *testing.T) {
+	// set_timeout must stay within its module instance instead of leaking
+	// into every machine in the process via the package-level variable
+	m1 := lh.NewModule()
+	m2 := lh.NewModule()
+	script1 := itn.HereDoc(`
+		load('http', 'set_timeout', 'get_timeout')
+		set_timeout(5)
+		assert.eq(get_timeout(), 5)
+	`)
+	if _, err := itn.ExecModuleWithErrorTest(t, lh.ModuleName, m1.LoadModule, script1, "", nil); err != nil {
+		t.Fatalf("module 1 expects no error, got: %v", err)
+	}
+	script2 := itn.HereDoc(`
+		load('http', 'get_timeout')
+		assert.eq(get_timeout(), 30)
+	`)
+	if _, err := itn.ExecModuleWithErrorTest(t, lh.ModuleName, m2.LoadModule, script2, "", nil); err != nil {
+		t.Fatalf("module 2 must not see module 1's timeout, got: %v", err)
+	}
+
+	// the package-level knob still seeds new instances
+	lh.ConfigLock.Lock()
+	lh.TimeoutSecond = 42
+	lh.ConfigLock.Unlock()
+	defer func() {
+		lh.ConfigLock.Lock()
+		lh.TimeoutSecond = 30.0
+		lh.ConfigLock.Unlock()
+	}()
+	m3 := lh.NewModule()
+	script3 := itn.HereDoc(`
+		load('http', 'get_timeout')
+		assert.eq(get_timeout(), 42)
+	`)
+	if _, err := itn.ExecModuleWithErrorTest(t, lh.ModuleName, m3.LoadModule, script3, "", nil); err != nil {
+		t.Fatalf("expected the package default to seed the instance, got: %v", err)
+	}
+}
+
+func TestModuleInjectedClientRejectsTransportArgs(t *testing.T) {
+	wantErr := `conflicts with the http client provided by the host`
+	tests := []struct {
+		name   string
+		script string
+	}{
+		{name: "timeout kwarg", script: "res = get('http://127.0.0.1:1/', timeout=3)"},
+		{name: "allow_redirects kwarg", script: "res = get('http://127.0.0.1:1/', allow_redirects=False)"},
+		{name: "verify kwarg", script: "res = get('http://127.0.0.1:1/', verify=False)"},
+		{name: "timeout positional", script: `res = get('http://127.0.0.1:1/', None, None, None, None, None, "", ("u", "p"), 3)`},
+		{name: "allow_redirects positional", script: `res = get('http://127.0.0.1:1/', None, None, None, None, None, "", ("u", "p"), 3, False)`},
+		{name: "verify positional", script: `res = get('http://127.0.0.1:1/', None, None, None, None, None, "", ("u", "p"), 3, False, True)`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			md := lh.NewModule()
+			md.SetClient(&http.Client{})
+			script := "load('http', 'get')\n" + tt.script
+			res, err := itn.ExecModuleWithErrorTest(t, lh.ModuleName, md.LoadModule, script, wantErr, nil)
+			if err == nil {
+				t.Errorf("expected a conflict error, got result: %v", res)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

`set_timeout` wrote the package-level `TimeoutSecond` (Backlog **LET-10**, 确定性): one script's setting leaked into **every machine in the process** and persisted across runs — the test suite even reset it manually between cases. The request path additionally read `TimeoutSecond`/`DisableRedirect`/`SkipInsecureVerify` (and `setHeaders` read `UserAgent`) **without** `ConfigLock`, racing with any concurrent writer — a real data race with parallel machines. And with a host-injected client, explicit `timeout`/`allow_redirects`/`verify` arguments were silently dropped while `get_timeout` kept reporting a value that did not apply.

## What

- The default timeout lives on the **Module instance** (own small lock); `set_timeout`/`get_timeout` are instance methods. Each Machine gets its own Module, so isolation falls out naturally; sharing one Module across machines remains an explicit host opt-in.
- The package-level `TimeoutSecond` **seeds** new instances — the documented host pattern `lh.TimeoutSecond = X` before load keeps working (pinned by a test).
- The request path snapshots the package knobs under `ConfigLock`; the unlocked reads are gone.
- With a host-injected client, an explicit `timeout`/`allow_redirects`/`verify` argument now **errors loudly** (keyword or positional) instead of being silently ignored.

## Behavior change

Cross-machine `set_timeout` propagation disappears (that was the bug); hosts injecting a client will see errors from scripts that pass transport arguments that never worked anyway. README updated ("global timeout" wording corrected).

Test-first: instance isolation, package-seed, and all six conflict forms (3 kwargs + 3 positional) are pinned; the pre-existing in-script `set_timeout→get` timeout case passes unchanged on instance semantics.

Refs: LET-10

🤖 Generated with [Claude Code](https://claude.com/claude-code)