### PR TITLE
[feat] LET-11: ForceTLSVerify — hosts can forbid disabling TLS verification

### DIFF
--- a/lib/http/http.go
+++ b/lib/http/http.go
@@ -44,6 +44,11 @@ var (
 	// response; 0 means unlimited. It seeds new module instances, override
 	// with a custom value before calling LoadModule.
 	MaxResponseBodyBytes int64
+	// ForceTLSVerify, when true, refuses requests that pass verify=False
+	// and ignores SkipInsecureVerify, so scripts cannot turn off TLS
+	// certificate verification. It seeds new module instances, override
+	// with a custom value before calling LoadModule.
+	ForceTLSVerify bool
 	// ConfigLock is a global lock for settings, use it to ensure thread safety when setting.
 	ConfigLock sync.RWMutex
 )
@@ -66,6 +71,7 @@ type Module struct {
 	mu          sync.RWMutex
 	timeoutSec  float64
 	maxBodySize int64
+	forceVerify bool
 }
 
 // NewModule creates a new http module with default settings. The package
@@ -75,7 +81,7 @@ type Module struct {
 func NewModule() *Module {
 	ConfigLock.RLock()
 	defer ConfigLock.RUnlock()
-	m := &Module{timeoutSec: TimeoutSecond, maxBodySize: MaxResponseBodyBytes}
+	m := &Module{timeoutSec: TimeoutSecond, maxBodySize: MaxResponseBodyBytes, forceVerify: ForceTLSVerify}
 	if Client != nil {
 		m.cli = Client
 	}
@@ -97,6 +103,24 @@ func (m *Module) maxBodyBytes() int64 {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.maxBodySize
+}
+
+// tlsVerifyForced reports whether the host forbids disabling TLS verification.
+func (m *Module) tlsVerifyForced() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.forceVerify
+}
+
+// SetForceTLSVerify controls whether scripts may disable TLS certificate
+// verification for this module instance. When forced, verify=False is
+// rejected loudly and the SkipInsecureVerify package default is ignored.
+// Hosts running untrusted scripts should force verification: a script
+// that can turn off TLS checks can be man-in-the-middled.
+func (m *Module) SetForceTLSVerify(force bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.forceVerify = force
 }
 
 // SetMaxResponseBodyBytes limits how many bytes body()/json() will read
@@ -204,6 +228,11 @@ func (m *Module) reqMethod(method string) func(thread *starlark.Thread, b *starl
 		defaultRedirect := !DisableRedirect
 		defaultVerify := !SkipInsecureVerify
 		ConfigLock.RUnlock()
+		forceVerify := m.tlsVerifyForced()
+		if forceVerify {
+			// the host policy wins over the package-level default
+			defaultVerify = true
+		}
 		var (
 			getDefaultDict = func() *types.NullableDict { return types.NewNullableDict(starlark.NewDict(0)) }
 			urlv           starlark.String
@@ -222,6 +251,12 @@ func (m *Module) reqMethod(method string) func(thread *starlark.Thread, b *starl
 		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "url", &urlv, "params?", params, "headers", headers, "body", body, "json_body", &jsonBody, "form_body", formBody, "form_encoding", &formEncoding,
 			"auth?", &auth, "timeout?", &timeout, "allow_redirects?", &allowRedirect, "verify?", &verifySSL); err != nil {
 			return nil, err
+		}
+
+		// a host that forces TLS verification refuses the verify=False
+		// escape hatch outright
+		if forceVerify && !bool(verifySSL) {
+			return nil, fmt.Errorf("%s: verify=False is not allowed by the host policy", b.Name())
 		}
 
 		// with a host-injected client, per-request transport options cannot

--- a/lib/http/http_test.go
+++ b/lib/http/http_test.go
@@ -903,3 +903,50 @@ func TestRequestBodyKindsConflict(t *testing.T) {
 		t.Errorf("expected a mutual-exclusion error")
 	}
 }
+
+func TestModuleForceTLSVerify(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+	extra := starlark.StringDict{"test_url": starlark.String(ts.URL)}
+
+	// with the policy forced, verify=False is refused outright
+	md := lh.NewModule()
+	md.SetForceTLSVerify(true)
+	script := itn.HereDoc(`
+		load('http', 'get')
+		get(test_url, verify=False)
+	`)
+	if _, err := itn.ExecModuleWithErrorTest(t, lh.ModuleName, md.LoadModule, script, `verify=False is not allowed by the host policy`, extra); err == nil {
+		t.Errorf("expected the policy to refuse verify=False")
+	}
+
+	// ordinary requests keep working under the policy
+	script2 := itn.HereDoc(`
+		load('http', 'get')
+		res = get(test_url)
+		assert.eq(res.status_code, 200)
+	`)
+	if _, err := itn.ExecModuleWithErrorTest(t, lh.ModuleName, md.LoadModule, script2, "", extra); err != nil {
+		t.Errorf("expected plain requests to pass under the policy, got: %v", err)
+	}
+
+	// the policy overrides the package-level SkipInsecureVerify default
+	lh.ConfigLock.Lock()
+	lh.SkipInsecureVerify = true
+	lh.ForceTLSVerify = true
+	lh.ConfigLock.Unlock()
+	defer func() {
+		lh.ConfigLock.Lock()
+		lh.SkipInsecureVerify = false
+		lh.ForceTLSVerify = false
+		lh.ConfigLock.Unlock()
+	}()
+	if _, err := itn.ExecModuleWithErrorTest(t, lh.ModuleName, lh.LoadModule, script2, "", extra); err != nil {
+		t.Errorf("expected the seeded policy to pass plain requests, got: %v", err)
+	}
+	if _, err := itn.ExecModuleWithErrorTest(t, lh.ModuleName, lh.LoadModule, script, `verify=False is not allowed by the host policy`, extra); err == nil {
+		t.Errorf("expected the seeded policy to refuse verify=False")
+	}
+}


### PR DESCRIPTION
## Why

Any script could pass `verify=False` and silently disable certificate verification for its requests — a MITM exposure when running untrusted scripts (Backlog **LET-11**, 安全). The package-level `SkipInsecureVerify` knob likewise disabled verification process-wide.

## What

- **`Module.SetForceTLSVerify(true)`** (+ package-level `ForceTLSVerify` seed): `verify=False` fails loudly (`verify=False is not allowed by the host policy`), and the `SkipInsecureVerify` default is neutralized while forced.
- **Default off — zero behavior change.** The `verify` parameter itself stays: self-signed endpoints are a legitimate use, and both the README and an existing test pin it as a supported feature. The knob is for L3/host policy layers to flip for untrusted-script profiles.
- The Backlog's RequestGuard route was rejected as infeasible: the interface only sees `*http.Request` and cannot observe TLS/client options without breaking every existing guard implementation (noted for the capability-gating design).

Tests: refusal under instance policy; plain requests unaffected under policy; the package seed both passes plain requests and refuses `verify=False` even with `SkipInsecureVerify=true` set.

Refs: LET-11

🤖 Generated with [Claude Code](https://claude.com/claude-code)