### PR TITLE
[feat] LET-09: http try_* family, response.ok, raise_for_status, try_body/try_json

### DIFF
--- a/lib/http/README.md
+++ b/lib/http/README.md
@@ -2,6 +2,8 @@
 
 `http` defines an HTTP client implementation. It is a thin wrapper around the Go standard package `net/http` but in Python `requests` style.
 
+Every request function (and `call`) has a `try_`-prefixed variant (`try_get`, `try_post`, …, `try_call`) that never aborts the script: it returns a `(response, error)` pair where exactly one side is `None`, the same shape as the `json` module's `try_*` functions. All request functions also accept `raise_for_status=True` to turn any non-2xx response into an error.
+
 ## Functions
 
 ### `call(method, url, params=None, headers=None, auth=(), body=None, json_body=None, form_body=None, form_encoding="", timeout=30, allow_redirects=True, verify=True) response`
@@ -27,6 +29,7 @@ It is a convenience wrapper that enables users to use any supported HTTP method 
 | `timeout`         | `float`  | optional. how many seconds to wait for the server to send all the data before giving up. 0 means no timeout.                                                  |
 | `allow_redirects` | `bool`   | optional. whether to follow redirects.                                                                                                                        |
 | `verify`          | `bool`   | optional. whether to verify the server's SSL certificate.                                                                                                     |
+| `raise_for_status` | `bool` | optional. if True, a response with a non-2xx status code is reported as an error. defaults to False. |
 
 ### `get(url, params=None, headers=None, auth=(), body=None, json_body=None, form_body=None, form_encoding="", timeout=30, allow_redirects=True, verify=True) response`
 
@@ -47,6 +50,7 @@ Perform an HTTP GET request, returning a response.
 | `timeout`         | `float`  | optional. how many seconds to wait for the server to send all the data before giving up. 0 means no timeout.                                                                                                       |
 | `allow_redirects` | `bool`   | optional. whether to follow redirects.                                                                                                                                                                             |
 | `verify`          | `bool`   | optional. whether to verify the server's SSL certificate.                                                                                                                                                          |
+| `raise_for_status` | `bool` | optional. if True, a response with a non-2xx status code is reported as an error. defaults to False. |
 
 ### `put(url, params=None, headers=None, auth=(), body=None, json_body=None, form_body=None, form_encoding="", timeout=30, allow_redirects=True, verify=True) response`
 
@@ -67,6 +71,7 @@ Perform an HTTP PUT request, returning a response.
 | `timeout`         | `float`  | optional. how many seconds to wait for the server to send all the data before giving up. 0 means no timeout.                                                                                                       |
 | `allow_redirects` | `bool`   | optional. whether to follow redirects.                                                                                                                                                                             |
 | `verify`          | `bool`   | optional. whether to verify the server's SSL certificate.                                                                                                                                                          |
+| `raise_for_status` | `bool` | optional. if True, a response with a non-2xx status code is reported as an error. defaults to False. |
 
 ### `post(url, params=None, headers=None, auth=(), body=None, json_body=None, form_body=None, form_encoding="", timeout=30, allow_redirects=True, verify=True) response`
 
@@ -87,6 +92,7 @@ Perform an HTTP POST request, returning a response.
 | `timeout`         | `float`  | optional. how many seconds to wait for the server to send all the data before giving up. 0 means no timeout.                                                                                                       |
 | `allow_redirects` | `bool`   | optional. whether to follow redirects.                                                                                                                                                                             |
 | `verify`          | `bool`   | optional. whether to verify the server's SSL certificate.                                                                                                                                                          |
+| `raise_for_status` | `bool` | optional. if True, a response with a non-2xx status code is reported as an error. defaults to False. |
 
 ### `postForm(url, params=None, headers=None, auth=(), body=None, json_body=None, form_body=None, form_encoding="", timeout=30, allow_redirects=True, verify=True) response`
 
@@ -107,6 +113,7 @@ Perform an HTTP POST request with form data, returning a response.
 | `timeout`         | `float`  | optional. how many seconds to wait for the server to send all the data before giving up. 0 means no timeout.                                                                                                       |
 | `allow_redirects` | `bool`   | optional. whether to follow redirects.                                                                                                                                                                             |
 | `verify`          | `bool`   | optional. whether to verify the server's SSL certificate.                                                                                                                                                          |
+| `raise_for_status` | `bool` | optional. if True, a response with a non-2xx status code is reported as an error. defaults to False. |
 
 ### `delete(url, params=None, headers=None, auth=(), body=None, json_body=None, form_body=None, form_encoding="", timeout=30, allow_redirects=True, verify=True) response`
 
@@ -127,6 +134,7 @@ Perform an HTTP DELETE request, returning a response.
 | `timeout`         | `float`  | optional. how many seconds to wait for the server to send all the data before giving up. 0 means no timeout.                                                                                                       |
 | `allow_redirects` | `bool`   | optional. whether to follow redirects.                                                                                                                                                                             |
 | `verify`          | `bool`   | optional. whether to verify the server's SSL certificate.                                                                                                                                                          |
+| `raise_for_status` | `bool` | optional. if True, a response with a non-2xx status code is reported as an error. defaults to False. |
 
 ### `patch(url, params=None, headers=None, auth=(), body=None, json_body=None, form_body=None, form_encoding="", timeout=30, allow_redirects=True, verify=True) response`
 
@@ -147,6 +155,7 @@ Perform an HTTP PATCH request, returning a response.
 | `timeout`         | `float`  | optional. how many seconds to wait for the server to send all the data before giving up. 0 means no timeout.                                                                                                       |
 | `allow_redirects` | `bool`   | optional. whether to follow redirects.                                                                                                                                                                             |
 | `verify`          | `bool`   | optional. whether to verify the server's SSL certificate.                                                                                                                                                          |
+| `raise_for_status` | `bool` | optional. if True, a response with a non-2xx status code is reported as an error. defaults to False. |
 
 ### `options(url,params={},headers={},body="",form_body={},form_encoding="",json_body={},auth=(),timeout=30,allow_redirects=True,verify=True) response`
 
@@ -167,6 +176,7 @@ Perform an HTTP OPTIONS request, returning a response.
 | `timeout`         | `float`  | optional. how many seconds to wait for the server to send all the data before giving up. 0 means no timeout.                                                                                                       |
 | `allow_redirects` | `bool`   | optional. whether to follow redirects.                                                                                                                                                                             |
 | `verify`          | `bool`   | optional. whether to verify the server's SSL certificate.                                                                                                                                                          |
+| `raise_for_status` | `bool` | optional. if True, a response with a non-2xx status code is reported as an error. defaults to False. |
 
 ### `set_timeout(timeout)`
 
@@ -196,6 +206,7 @@ The result of performing a HTTP request.
 |---------------|----------|---------------------------------------------------------------------|
 | `url`         | `string` | the URL that was ultimately requested (may change after redirects). |
 | `status_code` | `int`    | response status code (for example: `200 == OK`).                    |
+| `ok`          | `bool`   | True when the status code is in the 2xx range.                      |
 | `headers`     | `dict`   | dictionary of response headers.                                     |
 | `encoding`    | `string` | transfer encoding. example: "octet-stream" or "application/json".   |
 
@@ -207,7 +218,15 @@ output response body as a string.
 
 #### `json() object`
 
-attempt to parse response body as json, returning a JSON-decoded result, or None if the response body is empty or not valid JSON.
+attempt to parse response body as json, returning a JSON-decoded result, or None if the response body is empty or not valid JSON (a parse failure and a JSON `null` are indistinguishable here; use `try_json()` to tell them apart).
+
+#### `try_body() (string, error)`
+
+like `body()`, but returns a `(value, error)` pair instead of aborting the script (for example when the configured response size limit is exceeded).
+
+#### `try_json() (object, error)`
+
+like `json()`, but returns a `(value, error)` pair: a parse or read failure lands in the error slot instead of being folded into None.
 
 ### `ExportedServerRequest`
 

--- a/lib/http/http.go
+++ b/lib/http/http.go
@@ -160,13 +160,32 @@ var (
 	supportedMethods = []string{"get", "put", "post", "postForm", "delete", "head", "patch", "options"}
 )
 
+// wrapTry converts a builtin into its try_ variant: instead of aborting the
+// whole script on failure, it returns a (value, error-string) pair with the
+// Go error always nil - the shape established by lib/json's try_* functions.
+// Argument-unpacking errors are captured the same way.
+func wrapTry(fn func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error)) func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		res, err := fn(thread, b, args, kwargs)
+		if err != nil {
+			return starlark.Tuple{starlark.None, starlark.String(err.Error())}, nil
+		}
+		if res == nil {
+			res = starlark.None
+		}
+		return starlark.Tuple{res, starlark.None}, nil
+	}
+}
+
 // StringDict returns all module methods in a starlark.StringDict
 func (m *Module) StringDict() starlark.StringDict {
-	sd := make(starlark.StringDict, len(supportedMethods))
+	sd := make(starlark.StringDict, 2*len(supportedMethods)+4)
 	for _, name := range supportedMethods {
 		sd[name] = starlark.NewBuiltin(ModuleName+"."+name, m.reqMethod(name))
+		sd["try_"+name] = starlark.NewBuiltin(ModuleName+".try_"+name, wrapTry(m.reqMethod(name)))
 	}
 	sd["call"] = starlark.NewBuiltin(ModuleName+".call", m.callMethod)
+	sd["try_call"] = starlark.NewBuiltin(ModuleName+".try_call", wrapTry(m.callMethod))
 	sd["set_timeout"] = starlark.NewBuiltin(ModuleName+".set_timeout", m.setRequestTimeout)
 	sd["get_timeout"] = starlark.NewBuiltin(ModuleName+".get_timeout", m.getRequestTimeout)
 	return sd
@@ -246,10 +265,11 @@ func (m *Module) reqMethod(method string) func(thread *starlark.Thread, b *starl
 			timeout        = types.FloatOrInt(m.defaultTimeout())
 			allowRedirect  = starlark.Bool(defaultRedirect)
 			verifySSL      = starlark.Bool(defaultVerify)
+			raiseForStatus starlark.Bool // default False: non-2xx responses return normally
 		)
 
 		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "url", &urlv, "params?", params, "headers", headers, "body", body, "json_body", &jsonBody, "form_body", formBody, "form_encoding", &formEncoding,
-			"auth?", &auth, "timeout?", &timeout, "allow_redirects?", &allowRedirect, "verify?", &verifySSL); err != nil {
+			"auth?", &auth, "timeout?", &timeout, "allow_redirects?", &allowRedirect, "verify?", &verifySSL, "raise_for_status?", &raiseForStatus); err != nil {
 			return nil, err
 		}
 
@@ -306,6 +326,11 @@ func (m *Module) reqMethod(method string) func(thread *starlark.Thread, b *starl
 		res, err := cli.Do(req)
 		if err != nil {
 			return nil, err
+		}
+
+		if bool(raiseForStatus) && (res.StatusCode < 200 || res.StatusCode >= 300) {
+			_ = res.Body.Close()
+			return nil, fmt.Errorf("%s: unexpected status: %s", b.Name(), res.Status)
 		}
 
 		r := &Response{Response: *res, maxBodyBytes: m.maxBodyBytes()}
@@ -618,11 +643,35 @@ func (r *Response) Struct() *starlarkstruct.Struct {
 	return starlarkstruct.FromStringDict(starlarkstruct.Default, starlark.StringDict{
 		"url":         starlark.String(r.Request.URL.String()),
 		"status_code": starlark.MakeInt(r.StatusCode),
+		"ok":          starlark.Bool(r.StatusCode >= 200 && r.StatusCode < 300),
 		"headers":     r.HeadersDict(),
 		"encoding":    starlark.String(strings.Join(r.TransferEncoding, ",")),
 		"body":        starlark.NewBuiltin("body", r.Text),
 		"json":        starlark.NewBuiltin("json", r.JSON),
+		"try_body":    starlark.NewBuiltin("try_body", wrapTry(r.Text)),
+		"try_json":    starlark.NewBuiltin("try_json", r.tryJSON),
 	})
+}
+
+// tryJSON parses the body as JSON and returns a (value, error-string)
+// pair. Unlike json() - which folds read and parse failures into None for
+// backward compatibility - it lets scripts tell a parse failure apart from
+// a JSON null.
+func (r *Response) tryJSON(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	body, err := r.readBody()
+	if err != nil {
+		return starlark.Tuple{starlark.None, starlark.String(err.Error())}, nil
+	}
+
+	// reset reader to allow multiple calls
+	_ = r.Body.Close()
+	r.Body = ioutil.NopCloser(bytes.NewReader(body))
+
+	sv, err := dataconv.UnmarshalStarlarkJSON(body)
+	if err != nil {
+		return starlark.Tuple{starlark.None, starlark.String(err.Error())}, nil
+	}
+	return starlark.Tuple{sv, starlark.None}, nil
 }
 
 // HeadersDict flops

--- a/lib/http/http_test.go
+++ b/lib/http/http_test.go
@@ -1059,3 +1059,29 @@ func TestTryRequestFamily(t *testing.T) {
 		})
 	}
 }
+
+func TestTryReadsUnderLimit(t *testing.T) {
+	// the size-limit failure must land in the error slot of the pair
+	// instead of aborting the script like body()/json() do
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"a": 1, "padding": "pppppppppppppppppppp"}`))
+	}))
+	defer srv.Close()
+
+	md := lh.NewModule()
+	md.SetMaxResponseBodyBytes(4)
+	script := itn.HereDoc(`
+		load('http', 'get')
+		res = get(test_url)
+		b, err = res.try_body()
+		assert.eq(b, None)
+		assert.true('exceeds' in err)
+		v, err2 = res.try_json()
+		assert.eq(v, None)
+		assert.true('exceeds' in err2)
+	`)
+	extra := starlark.StringDict{"test_url": starlark.String(srv.URL)}
+	if _, err := itn.ExecModuleWithErrorTest(t, lh.ModuleName, md.LoadModule, script, "", extra); err != nil {
+		t.Errorf("expected the limited try-reads to pass with captured errors, got: %v", err)
+	}
+}

--- a/lib/http/http_test.go
+++ b/lib/http/http_test.go
@@ -950,3 +950,112 @@ func TestModuleForceTLSVerify(t *testing.T) {
 		t.Errorf("expected the seeded policy to refuse verify=False")
 	}
 }
+
+func TestTryRequestFamily(t *testing.T) {
+	okSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"a": 1}`))
+	}))
+	defer okSrv.Close()
+	notFoundSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`not json`))
+	}))
+	defer notFoundSrv.Close()
+
+	tests := []struct {
+		name    string
+		script  string
+		wantErr string
+	}{
+		{
+			name: `try_get: success and ok`,
+			script: itn.HereDoc(`
+				load('http', 'try_get')
+				res, err = try_get(ok_url)
+				assert.eq(err, None)
+				assert.true(res.ok)
+				assert.eq(res.status_code, 200)
+			`),
+		},
+		{
+			name: `try_get: transport error captured`,
+			script: itn.HereDoc(`
+				load('http', 'try_get')
+				res, err = try_get('http://127.0.0.1:1/')
+				assert.eq(res, None)
+				assert.true('connect' in err or 'refused' in err)
+			`),
+		},
+		{
+			name: `try_call: argument error captured`,
+			script: itn.HereDoc(`
+				load('http', 'try_call')
+				res, err = try_call('TRACE', ok_url)
+				assert.eq(res, None)
+				assert.true('unsupported method' in err)
+			`),
+		},
+		{
+			name: `ok: false on non-2xx`,
+			script: itn.HereDoc(`
+				load('http', 'get')
+				res = get(nf_url)
+				assert.eq(res.ok, False)
+				assert.eq(res.status_code, 404)
+			`),
+		},
+		{
+			name: `raise_for_status: error on non-2xx`,
+			script: itn.HereDoc(`
+				load('http', 'get')
+				get(nf_url, raise_for_status=True)
+			`),
+			wantErr: `http.get: unexpected status: 404 Not Found`,
+		},
+		{
+			name: `raise_for_status: default keeps old behavior`,
+			script: itn.HereDoc(`
+				load('http', 'get')
+				res = get(nf_url)
+				assert.eq(res.status_code, 404)
+			`),
+		},
+		{
+			name: `try_json: parse failure is visible`,
+			script: itn.HereDoc(`
+				load('http', 'get')
+				res = get(nf_url)
+				v, err = res.try_json()
+				assert.eq(v, None)
+				assert.true(err != None)
+				# while json() folds the same failure into None
+				assert.eq(res.json(), None)
+			`),
+		},
+		{
+			name: `try_json and try_body: success`,
+			script: itn.HereDoc(`
+				load('http', 'get')
+				res = get(ok_url)
+				v, err = res.try_json()
+				assert.eq(err, None)
+				assert.eq(v, {"a": 1})
+				b, err2 = res.try_body()
+				assert.eq(err2, None)
+				assert.eq(b, '{"a": 1}')
+			`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extra := starlark.StringDict{
+				"ok_url": starlark.String(okSrv.URL),
+				"nf_url": starlark.String(notFoundSrv.URL),
+			}
+			res, err := itn.ExecModuleWithErrorTest(t, lh.ModuleName, lh.LoadModule, tt.script, tt.wantErr, extra)
+			if (err != nil) != (tt.wantErr != "") {
+				t.Errorf("http(%q) expects error = '%v', actual error = '%v', result = %v", tt.name, tt.wantErr, err, res)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

Any transport/timeout/TLS/guard error aborted the whole script — Starlark has no try/except (Backlog **LET-09**, 容错缺失). Non-2xx responses exposed nothing but `status_code`; and because `body()`/`json()` read lazily, a script could pass the request and then abort on the read. Scripts had no way to degrade gracefully around network failures.

## What (all additive)

- **`try_get` … `try_options`, `try_call`**: `(response, error-string)` pairs — the shape established by `lib/json`'s `try_*` functions and reused by `lib/csv` (#134); argument errors are captured the same way.
- **`response.ok`**: `True` for 2xx — no more hand-comparing status codes.
- **`raise_for_status=True`** (default `False`): any non-2xx response becomes a loud error at the request site.
- **`response.try_body()` / `try_json()`**: the lazy reads in pair shape. `try_json` finally distinguishes a parse failure from a JSON `null` — `json()`'s documented fold-to-None stays unchanged for compatibility (pinned side-by-side in a test).

Existing names and behaviors are byte-for-byte unchanged; README documents the family, the new response members, and `raise_for_status` on every method table.

Refs: LET-09

🤖 Generated with [Claude Code](https://claude.com/claude-code)