### PR TITLE
[feat] runtime: expose tempdir (the default directory for temporary files)

### DIFF
--- a/lib/runtime/README.md
+++ b/lib/runtime/README.md
@@ -7,6 +7,7 @@
 - `hostname`: A string representing the hostname of the system where the script is being executed.
 - `workdir`: A string representing the current working directory of the process.
 - `homedir`: A string representing the home directory of the user running the process, it's `$HOME` on Unix/Linux, `%USERPROFILE%` on Windows.
+- `tempdir`: A string representing the default directory to use for temporary files. This is similar to Python's `tempfile.gettempdir()`.
 - `os`: A string representing the operating system of the runtime. This value comes from Go's `runtime.GOOS`.
 - `arch`: A string representing the architecture of the machine. This value is derived from Go's `runtime.GOARCH`.
 - `gover`: A string representing the Go runtime version. This is obtained using `runtime.Version()` from the Go standard library.

--- a/lib/runtime/runtime.go
+++ b/lib/runtime/runtime.go
@@ -41,6 +41,7 @@ func LoadModule() (md starlark.StringDict, err error) {
 					"hostname":  starlark.String(host),
 					"workdir":   starlark.String(pwd),
 					"homedir":   starlark.String(hd),
+					"tempdir":   starlark.String(os.TempDir()),
 					"os":        starlark.String(grt.GOOS),
 					"arch":      starlark.String(grt.GOARCH),
 					"gover":     starlark.String(grt.Version()),

--- a/lib/runtime/runtime_test.go
+++ b/lib/runtime/runtime_test.go
@@ -16,10 +16,18 @@ func TestLoadModule_Runtime(t *testing.T) {
 		{
 			name: `host`,
 			script: itn.HereDoc(`
-				load('runtime', 'hostname', 'workdir', 'homedir', 'os', 'arch', 'gover')
-				ss = [hostname, workdir, homedir, os, arch, gover]
+				load('runtime', 'hostname', 'workdir', 'homedir', 'tempdir', 'os', 'arch', 'gover')
+				ss = [hostname, workdir, homedir, tempdir, os, arch, gover]
 				print(ss)
 				_ = [assert.eq(type(s), "string") for s in ss]
+			`),
+		},
+		{
+			name: `tempdir`,
+			script: itn.HereDoc(`
+				load('runtime', 'tempdir')
+				assert.eq(type(tempdir), "string")
+				assert.ne(tempdir, "")
 			`),
 		},
 		{


### PR DESCRIPTION
Scripts that write scratch files had no portable way to find the platform temp directory. `runtime.tempdir` mirrors Go's `os.TempDir()` — similar to Python's `tempfile.gettempdir()`.

Reworked from an unmerged local branch (triaged as part of this series' planning); test and README included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)