### PR TITLE
[feat] LET-05: string head/tail/head_lines/tail_lines/truncate; honest quote docs

### DIFF
--- a/lib/string/README.md
+++ b/lib/string/README.md
@@ -280,7 +280,7 @@ print(unescape(s))
 
 ### `quote(str) string`
 
-Returns a shell-escaped version of the string str. This returns a string that can safely be used as one token in a shell command line.
+Returns a double-quoted string literal in Go syntax representing str, with control characters and non-printable runes escaped (like Go's `strconv.Quote`). NOTE: this is **not** shell escaping — do not use it to build shell command lines.
 
 #### Parameters
 
@@ -323,3 +323,23 @@ s = '"Hello\tWorld"'
 print(unquote(s))
 World
 ```
+
+### `head(s, n) string`
+
+Returns the first `n` characters (runes) of `s`. `n` must be non-negative and is clamped at the length of the string, so a short input never errors. Unlike the language-level `s[:n]`, the cut is rune-aware and never splits a multi-byte character.
+
+### `tail(s, n) string`
+
+Returns the last `n` characters (runes) of `s`, with the same clamping and rune-awareness as `head`.
+
+### `head_lines(s, n) string`
+
+Returns the first `n` lines of `s` (split on `\n`), clamped at the number of lines.
+
+### `tail_lines(s, n) string`
+
+Returns the last `n` lines of `s` (split on `\n`), clamped at the number of lines.
+
+### `truncate(s, length, suffix="...") string`
+
+Shortens `s` to at most `length` characters (runes). If a cut happens, `suffix` is appended and the result — including the suffix — never exceeds `length` runes; a string already within the limit is returned unchanged.

--- a/lib/string/string.go
+++ b/lib/string/string.go
@@ -54,18 +54,23 @@ func LoadModule() (starlark.StringDict, error) {
 					"printable":       starlark.String(printable),
 
 					// functions
-					"length":    starlark.NewBuiltin(ModuleName+".length", length),
-					"reverse":   starlark.NewBuiltin(ModuleName+".reverse", reverse),
-					"escape":    genStarStrBuiltin("escape", html.EscapeString),
-					"unescape":  genStarStrBuiltin("unescape", html.UnescapeString),
-					"quote":     genStarStrBuiltin("quote", strconv.Quote),
-					"unquote":   genStarStrBuiltin("unquote", robustUnquote),
-					"index":     starlark.NewBuiltin(ModuleName+".index", createIndexFunc("index", false, false)),
-					"find":      starlark.NewBuiltin(ModuleName+".find", createIndexFunc("find", false, true)),
-					"rindex":    starlark.NewBuiltin(ModuleName+".rindex", createIndexFunc("rindex", true, false)),
-					"rfind":     starlark.NewBuiltin(ModuleName+".rfind", createIndexFunc("rfind", true, true)),
-					"substring": starlark.NewBuiltin(ModuleName+".substring", substring),
-					"codepoint": starlark.NewBuiltin(ModuleName+".codepoint", codepoint),
+					"length":     starlark.NewBuiltin(ModuleName+".length", length),
+					"reverse":    starlark.NewBuiltin(ModuleName+".reverse", reverse),
+					"escape":     genStarStrBuiltin("escape", html.EscapeString),
+					"unescape":   genStarStrBuiltin("unescape", html.UnescapeString),
+					"quote":      genStarStrBuiltin("quote", strconv.Quote),
+					"unquote":    genStarStrBuiltin("unquote", robustUnquote),
+					"index":      starlark.NewBuiltin(ModuleName+".index", createIndexFunc("index", false, false)),
+					"find":       starlark.NewBuiltin(ModuleName+".find", createIndexFunc("find", false, true)),
+					"rindex":     starlark.NewBuiltin(ModuleName+".rindex", createIndexFunc("rindex", true, false)),
+					"rfind":      starlark.NewBuiltin(ModuleName+".rfind", createIndexFunc("rfind", true, true)),
+					"substring":  starlark.NewBuiltin(ModuleName+".substring", substring),
+					"codepoint":  starlark.NewBuiltin(ModuleName+".codepoint", codepoint),
+					"head":       starlark.NewBuiltin(ModuleName+".head", genHeadTail("head", false, false)),
+					"tail":       starlark.NewBuiltin(ModuleName+".tail", genHeadTail("tail", true, false)),
+					"head_lines": starlark.NewBuiltin(ModuleName+".head_lines", genHeadTail("head_lines", false, true)),
+					"tail_lines": starlark.NewBuiltin(ModuleName+".tail_lines", genHeadTail("tail_lines", true, true)),
+					"truncate":   starlark.NewBuiltin(ModuleName+".truncate", truncate),
 				},
 			},
 		}
@@ -240,6 +245,72 @@ func substring(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple
 	}
 
 	return starlark.String(rs[start:end]), nil
+}
+
+// genHeadTail builds the head/tail/head_lines/tail_lines builtins: the
+// first or last n runes (or lines) of a string. n is a non-negative count
+// and is clamped at the available length — unlike the language-level
+// byte slice s[a:b], the rune-based cut never splits a multi-byte
+// character, and clamping never errors on a short input.
+func genHeadTail(name string, fromEnd, byLines bool) func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var (
+			s string
+			n int
+		)
+		if err := starlark.UnpackArgs(name, args, kwargs, "s", &s, "n", &n); err != nil {
+			return none, err
+		}
+		if n < 0 {
+			return none, fmt.Errorf("%s: n must be non-negative", name)
+		}
+		if byLines {
+			lines := strings.Split(s, "\n")
+			if n > len(lines) {
+				n = len(lines)
+			}
+			if fromEnd {
+				return starlark.String(strings.Join(lines[len(lines)-n:], "\n")), nil
+			}
+			return starlark.String(strings.Join(lines[:n], "\n")), nil
+		}
+		rs := []rune(s)
+		if n > len(rs) {
+			n = len(rs)
+		}
+		if fromEnd {
+			return starlark.String(rs[len(rs)-n:]), nil
+		}
+		return starlark.String(rs[:n]), nil
+	}
+}
+
+// truncate shortens a string to at most length runes, appending the suffix
+// when a cut happens; the result (including the suffix) never exceeds
+// length runes. The cut is rune-aware, so multi-byte characters survive.
+func truncate(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		s      string
+		length int
+		suffix = "..."
+	)
+	if err := starlark.UnpackArgs("truncate", args, kwargs, "s", &s, "length", &length, "suffix?", &suffix); err != nil {
+		return none, err
+	}
+	if length < 0 {
+		return none, fmt.Errorf("truncate: length must be non-negative")
+	}
+	rs := []rune(s)
+	if len(rs) <= length {
+		return starlark.String(s), nil
+	}
+	sr := []rune(suffix)
+	keep := length - len(sr)
+	if keep < 0 {
+		keep = 0
+		sr = sr[:length]
+	}
+	return starlark.String(string(rs[:keep]) + string(sr)), nil
 }
 
 // codepoint returns the Unicode codepoint of the character at the given index.

--- a/lib/string/string_test.go
+++ b/lib/string/string_test.go
@@ -463,3 +463,91 @@ func TestLoadModule_String(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadModule_String_HeadTailTruncate(t *testing.T) {
+	tests := []struct {
+		name    string
+		script  string
+		wantErr string
+	}{
+		{
+			name: `head and tail`,
+			script: itn.HereDoc(`
+				load('string', 'head', 'tail')
+				assert.eq(head('hello', 2), 'he')
+				assert.eq(head('hello', 99), 'hello')
+				assert.eq(head('hello', 0), '')
+				assert.eq(head('你好世界', 2), '你好')
+				assert.eq(tail('hello', 2), 'lo')
+				assert.eq(tail('hello', 99), 'hello')
+				assert.eq(tail('你好世界', 2), '世界')
+				assert.eq(tail('a☕c', 2), '☕c')
+			`),
+		},
+		{
+			name: `head negative`,
+			script: itn.HereDoc(`
+				load('string', 'head')
+				head('hello', -1)
+			`),
+			wantErr: `head: n must be non-negative`,
+		},
+		{
+			name: `tail negative`,
+			script: itn.HereDoc(`
+				load('string', 'tail')
+				tail('hello', -1)
+			`),
+			wantErr: `tail: n must be non-negative`,
+		},
+		{
+			name: `head_lines and tail_lines`,
+			script: itn.HereDoc(`
+				load('string', 'head_lines', 'tail_lines')
+				s = 'a\nb\nc'
+				assert.eq(head_lines(s, 2), 'a\nb')
+				assert.eq(head_lines(s, 99), s)
+				assert.eq(head_lines(s, 0), '')
+				assert.eq(tail_lines(s, 2), 'b\nc')
+				assert.eq(tail_lines(s, 99), s)
+			`),
+		},
+		{
+			name: `head_lines negative`,
+			script: itn.HereDoc(`
+				load('string', 'head_lines')
+				head_lines('a\nb', -2)
+			`),
+			wantErr: `head_lines: n must be non-negative`,
+		},
+		{
+			name: `truncate`,
+			script: itn.HereDoc(`
+				load('string', 'truncate')
+				assert.eq(truncate('hello world', 8), 'hello...')
+				assert.eq(truncate('hello', 99), 'hello')
+				assert.eq(truncate('hello', 5), 'hello')
+				assert.eq(truncate('hello world', 8, suffix='~'), 'hello w~')
+				assert.eq(truncate('你好世界你好世界', 5), '你好...')
+				assert.eq(truncate('hello', 2), '..')
+				assert.eq(truncate('hello', 0), '')
+			`),
+		},
+		{
+			name: `truncate negative`,
+			script: itn.HereDoc(`
+				load('string', 'truncate')
+				truncate('hello', -1)
+			`),
+			wantErr: `truncate: length must be non-negative`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := itn.ExecModuleWithErrorTest(t, ls.ModuleName, ls.LoadModule, tt.script, tt.wantErr, nil)
+			if (err != nil) != (tt.wantErr != "") {
+				t.Errorf("string(%q) expects error = '%v', actual error = '%v', result = %v", tt.name, tt.wantErr, err, res)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

The language-level slice `s[a:b]` is **byte-based** and happily splits a multi-byte character (CJK text corrupts), and `substring()` errors on out-of-range indices — there was no forgiving, rune-aware way to take "the first n chars" of untrusted-length text (Backlog **LET-05**).

## What (all additive)

Five rune-aware functions with counts clamped at the available length (short inputs never error):

- `head(s, n)` / `tail(s, n)` — first/last n runes
- `head_lines(s, n)` / `tail_lines(s, n)` — first/last n lines (names match `lib/file`'s same-shaped functions)
- `truncate(s, length, suffix="...")` — cut to at most `length` runes; the result **including the suffix** never exceeds `length`

`splitlines` from the original Backlog entry was deliberately dropped: native `str.splitlines()` already exists on the pinned interpreter — adding a same-named module function would be pure duplication (verified during planning).

## Docs

Also corrects the README's claim that `quote()` is *shell escaping* — it is Go `strconv.Quote` string-literal quoting and must not be used to build shell command lines (a real footgun for anyone trusting the old text).

Refs: LET-05

🤖 Generated with [Claude Code](https://claude.com/claude-code)
