### PR TITLE
[feat] LET-03+LET-04: path follows one rule — Python lexical semantics; chdir warning

### DIFF
--- a/lib/path/README.md
+++ b/lib/path/README.md
@@ -1,6 +1,22 @@
 # path
 
-`path` provides functions to manipulate directories and file paths. It is inspired by `pathlib` module from Mojo.
+`path` provides functions to manipulate directories and file paths. It follows one rule:
+
+- **Lexical functions** — `join`, `basename`, `dirname`, `normpath`, `split`, `splitext`, `isabs`, `relpath` — use **Python (`posixpath`) semantics**: pure string work on `/`-separated paths, no implicit cleaning, identical results on every OS.
+- **Filesystem functions** — `abs`, `exists`, `is_file`, `is_dir`, `is_link`, `listdir`, `getcwd`, `chdir`, `mkdir` — operate on the real, OS-native filesystem.
+
+## Migrating from v0.1.x
+
+`join` previously used Go's `filepath.Join`, which cleaned the result. With Python semantics:
+
+| call | v0.1.x | now |
+|---|---|---|
+| `join("a", "/b")` | `a/b` | `/b` (an absolute component resets the result) |
+| `join("a", "")` | `a` | `a/` (an empty component adds a trailing separator) |
+| `join("a", "../b")` | `b` | `a/../b` (no cleaning — apply `normpath` to collapse) |
+| `join("a//b", "c")` | `a/b/c` | `a//b/c` |
+
+Use `normpath(join(...))` where the old cleaned result is wanted.
 
 ## Functions
 
@@ -29,7 +45,7 @@ print(p)
 
 ### `join(path, *paths) string`
 
-Joins one or more path elements into a single path intelligently, separating them with an OS specific separator. Empty elements are ignored.
+Joins one or more path elements with Python (`posixpath`) semantics: components are joined with `/`, an absolute component resets the result, an empty component contributes a trailing separator, and no cleaning is applied (see the migration notes above).
 
 #### Parameters
 
@@ -221,7 +237,9 @@ print(p)
 
 ### `chdir(path)`
 
-Changes the current working directory.
+Changes the current working directory **of the whole process**.
+
+> ⚠️ The effect is global: it applies to every machine and goroutine in the host, persists after the script ends, and concurrent machines calling it race with each other. Never expose this module to untrusted scripts; host runtimes typically exclude `path` from restricted module sets for this reason.
 
 #### Parameters
 
@@ -273,3 +291,39 @@ load("path", "mkdir")
 mkdir('secure_directory', 0o700)
 # New directory named 'secure_directory' is created with permissions set to 0700
 ```
+
+### `basename(path) string`
+
+Returns the final component of a path — everything after the last `/`; a path ending in `/` has an empty basename (`basename("a/b/")` is `""`, unlike Go's `filepath.Base`).
+
+### `dirname(path) string`
+
+Returns the directory part of a path — everything before the last `/`, with trailing slashes stripped unless the result is all slashes.
+
+### `normpath(path) string`
+
+Collapses redundant separators and up-level references lexically: `a//b`, `a/./b` and `a/c/../b` all become `a/b`. Exactly two leading slashes are preserved (POSIX gives them special meaning); an empty path normalizes to `.`.
+
+### `split(path) (string, string)`
+
+Splits a path into a `(head, tail)` pair: `split("/a")` is `("/", "a")`, `split("a/b/")` is `("a/b", "")`.
+
+### `splitext(path) (string, string)`
+
+Splits a path into a `(root, extension)` pair: `splitext("a/b.tar.gz")` is `("a/b.tar", ".gz")`; leading dots do not count, so `splitext(".bashrc")` is `(".bashrc", "")`.
+
+### `isabs(path) bool`
+
+Reports whether the path is absolute (starts with `/`).
+
+### `relpath(path, start=".") string`
+
+Returns a relative path to `path` from `start`, computed lexically on the normalized inputs. Mixing an absolute path with a relative one is an error here — resolving the mix would silently depend on the process working directory; call `abs()` first when that is intended. `try_relpath` returns a `(value, error)` pair instead of aborting.
+
+### `expanduser(path) string`
+
+Replaces a leading `~` with the current user's home directory. Only the bare `~`/`~/...` form expands; `~user/...` is returned unchanged. Note that this reads the host environment.
+
+### `try_abs(path) (string, error)` / `try_relpath(path, start=".") (string, error)`
+
+The `(value, error)` pair forms of `abs` and `relpath`, never aborting the script — the same shape as the `json`/`csv`/`http` modules' `try_*` functions.

--- a/lib/path/path.go
+++ b/lib/path/path.go
@@ -1,10 +1,21 @@
-// Package path defines functions that manipulate directories, it's inspired by pathlib module from Mojo.
+// Package path provides path manipulation for Starlark. The lexical
+// functions (join, basename, dirname, normpath, split, splitext, isabs,
+// relpath) follow Python's posixpath semantics - pure string work on
+// "/"-separated paths, identical on every OS - while the filesystem
+// functions (abs, exists, is_file, is_dir, is_link, listdir, getcwd,
+// chdir, mkdir) operate on the real, OS-native filesystem.
+//
+// WARNING: chdir changes the working directory of the WHOLE PROCESS - it
+// affects every machine and goroutine in the host, not just the calling
+// script, and concurrent machines calling it race with each other. Never
+// expose this module to untrusted scripts.
 package path
 
 import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	tps "github.com/1set/starlet/dataconv/types"
@@ -28,6 +39,7 @@ func LoadModule() (starlark.StringDict, error) {
 				Name: ModuleName,
 				Members: starlark.StringDict{
 					"abs":     starlark.NewBuiltin(ModuleName+".abs", absPath),
+					"try_abs": starlark.NewBuiltin(ModuleName+".try_abs", wrapTry(absPath)),
 					"join":    starlark.NewBuiltin(ModuleName+".join", joinPaths),
 					"exists":  wrapExistPath("exists", checkExistPath),
 					"is_file": wrapExistPath("is_file", checkFileExist),
@@ -37,6 +49,18 @@ func LoadModule() (starlark.StringDict, error) {
 					"getcwd":  starlark.NewBuiltin(ModuleName+".getcwd", getCWD),
 					"chdir":   starlark.NewBuiltin(ModuleName+".chdir", changeCWD),
 					"mkdir":   starlark.NewBuiltin(ModuleName+".mkdir", makeDir),
+					// lexical functions with Python (posixpath) semantics:
+					// pure string work on "/"-separated paths, no cleaning
+					// beyond what each function defines, identical on every OS
+					"basename":    genLexical1("basename", pyBasename),
+					"dirname":     genLexical1("dirname", pyDirname),
+					"normpath":    genLexical1("normpath", pyNormpath),
+					"expanduser":  starlark.NewBuiltin(ModuleName+".expanduser", expandUser),
+					"isabs":       starlark.NewBuiltin(ModuleName+".isabs", isAbs),
+					"split":       starlark.NewBuiltin(ModuleName+".split", splitPath),
+					"splitext":    starlark.NewBuiltin(ModuleName+".splitext", splitExt),
+					"relpath":     starlark.NewBuiltin(ModuleName+".relpath", relPath),
+					"try_relpath": starlark.NewBuiltin(ModuleName+".try_relpath", wrapTry(relPath)),
 				},
 			},
 		}
@@ -73,9 +97,218 @@ func joinPaths(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple
 		}
 		paths[i] = s
 	}
-	// join paths
-	joined := filepath.Join(paths...)
+	// join paths with Python (posixpath) semantics: pure string joining,
+	// no cleaning. An absolute component resets the result; an empty
+	// component contributes a trailing separator. The previous
+	// filepath.Join behavior (collapse "..", drop empty parts, ignore
+	// absolute restarts, OS separator) is gone - see the README migration
+	// notes for the differences.
+	joined := paths[0]
+	for _, p := range paths[1:] {
+		switch {
+		case strings.HasPrefix(p, "/"):
+			joined = p
+		case joined == "" || strings.HasSuffix(joined, "/"):
+			joined += p
+		default:
+			joined += "/" + p
+		}
+	}
 	return starlark.String(joined), nil
+}
+
+// wrapTry converts a builtin into its try_ variant: instead of aborting the
+// whole script on failure, it returns a (value, error-string) pair with the
+// Go error always nil - the shape shared with the json/csv/http modules.
+func wrapTry(fn func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error)) func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		res, err := fn(thread, b, args, kwargs)
+		if err != nil {
+			return starlark.Tuple{starlark.None, starlark.String(err.Error())}, nil
+		}
+		if res == nil {
+			res = starlark.None
+		}
+		return starlark.Tuple{res, starlark.None}, nil
+	}
+}
+
+// genLexical1 wraps a pure string->string lexical helper as a builtin.
+func genLexical1(name string, fn func(string) string) *starlark.Builtin {
+	return starlark.NewBuiltin(ModuleName+"."+name, func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var path string
+		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "path", &path); err != nil {
+			return nil, err
+		}
+		return starlark.String(fn(path)), nil
+	})
+}
+
+// The helpers below hand-implement Python's posixpath semantics. The Go
+// standard library cannot be delegated to: path.Join/Clean normalize
+// eagerly, filepath.Base("a/b/") is "b" while Python's basename is "",
+// filepath.Dir cleans its result, and so on - each function is matched
+// against CPython's posixpath behavior in the tests.
+
+// pyBasename returns the final component of a path: everything after the
+// last slash, so a path with a trailing slash has an empty basename.
+func pyBasename(p string) string {
+	if i := strings.LastIndexByte(p, '/'); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}
+
+// pyDirname returns the directory part of a path: everything before the
+// last slash, with trailing slashes stripped unless the result is all
+// slashes (so dirname("//a") keeps "//").
+func pyDirname(p string) string {
+	i := strings.LastIndexByte(p, '/') + 1
+	head := p[:i]
+	if head != "" && head != strings.Repeat("/", len(head)) {
+		head = strings.TrimRight(head, "/")
+	}
+	return head
+}
+
+// pyNormpath collapses redundant separators and up-level references
+// lexically: "a//b", "a/./b" and "a/c/../b" all become "a/b". As in
+// Python, exactly two leading slashes are preserved (POSIX gives them
+// implementation-defined meaning) and an empty path normalizes to ".".
+func pyNormpath(p string) string {
+	if p == "" {
+		return "."
+	}
+	initialSlashes := 0
+	if strings.HasPrefix(p, "/") {
+		initialSlashes = 1
+		if strings.HasPrefix(p, "//") && !strings.HasPrefix(p, "///") {
+			initialSlashes = 2
+		}
+	}
+	var comps []string
+	for _, comp := range strings.Split(p, "/") {
+		if comp == "" || comp == "." {
+			continue
+		}
+		if comp != ".." || (initialSlashes == 0 && len(comps) == 0) || (len(comps) > 0 && comps[len(comps)-1] == "..") {
+			comps = append(comps, comp)
+		} else if len(comps) > 0 {
+			comps = comps[:len(comps)-1]
+		}
+	}
+	res := strings.Repeat("/", initialSlashes) + strings.Join(comps, "/")
+	if res == "" {
+		return "."
+	}
+	return res
+}
+
+// expandUser replaces a leading "~" with the current user's home
+// directory. Only the bare "~" form expands; "~user" is returned
+// unchanged (matching Python when the user lookup is unavailable), and so
+// is the path when the home directory cannot be determined.
+func expandUser(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var path string
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "path", &path); err != nil {
+		return nil, err
+	}
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil && home != "" {
+			return starlark.String(home + path[1:]), nil
+		}
+	}
+	return starlark.String(path), nil
+}
+
+// isAbs reports whether a path is absolute in the posix sense (starts
+// with a slash).
+func isAbs(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var path string
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "path", &path); err != nil {
+		return nil, err
+	}
+	return starlark.Bool(strings.HasPrefix(path, "/")), nil
+}
+
+// splitPath splits a path into a (head, tail) pair: tail is everything
+// after the last slash, head is the rest with trailing slashes stripped
+// unless it is all slashes - so split("/a") is ("/", "a") and
+// split("a/b/") is ("a/b", "").
+func splitPath(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var path string
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "path", &path); err != nil {
+		return nil, err
+	}
+	return starlark.Tuple{starlark.String(pyDirname(path)), starlark.String(pyBasename(path))}, nil
+}
+
+// splitExt splits a path into a (root, extension) pair. The extension is
+// the suffix beginning at the last dot in the final component; leading
+// dots do not count, so splitext(".bashrc") is (".bashrc", "").
+func splitExt(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var path string
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "path", &path); err != nil {
+		return nil, err
+	}
+	sepIdx := strings.LastIndexByte(path, '/')
+	dotIdx := strings.LastIndexByte(path, '.')
+	if dotIdx > sepIdx {
+		// the dot must come after at least one non-dot character of the
+		// final component, otherwise the name is dot-prefixed, not suffixed
+		for i := sepIdx + 1; i < dotIdx; i++ {
+			if path[i] != '.' {
+				return starlark.Tuple{starlark.String(path[:dotIdx]), starlark.String(path[dotIdx:])}, nil
+			}
+		}
+	}
+	return starlark.Tuple{starlark.String(path), starlark.String("")}, nil
+}
+
+// relPath returns a relative path to path from the start directory,
+// computed lexically on the normalized inputs. Both paths must be of the
+// same kind: mixing an absolute path with a relative one is an error here,
+// because resolving the mix would silently depend on the process working
+// directory (Python's os.path.relpath does exactly that; use abs() first
+// when that behavior is wanted).
+func relPath(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var path, start string
+	start = "."
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "path", &path, "start?", &start); err != nil {
+		return nil, err
+	}
+	if path == "" {
+		return nil, fmt.Errorf("%s: no path specified", b.Name())
+	}
+	if start == "" {
+		start = "."
+	}
+	if strings.HasPrefix(path, "/") != strings.HasPrefix(start, "/") {
+		return nil, fmt.Errorf("%s: cannot mix an absolute path with a relative start (resolve with abs() first)", b.Name())
+	}
+	splitComps := func(p string) []string {
+		var out []string
+		for _, c := range strings.Split(pyNormpath(p), "/") {
+			if c != "" && c != "." {
+				out = append(out, c)
+			}
+		}
+		return out
+	}
+	pc, sc := splitComps(path), splitComps(start)
+	i := 0
+	for i < len(pc) && i < len(sc) && pc[i] == sc[i] {
+		i++
+	}
+	var comps []string
+	for j := i; j < len(sc); j++ {
+		comps = append(comps, "..")
+	}
+	comps = append(comps, pc[i:]...)
+	if len(comps) == 0 {
+		return starlark.String("."), nil
+	}
+	return starlark.String(strings.Join(comps, "/")), nil
 }
 
 // wrapExistPath wraps the existPath function to be used in Starlark with a given function to check if the path exists.
@@ -192,7 +425,9 @@ func getCWD(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, k
 	return starlark.String(cwd), nil
 }
 
-// changeCWD changes the current working directory.
+// changeCWD changes the current working directory of the whole process:
+// the effect is global, leaks across machines and threads, and persists
+// after the script ends. See the package warning..
 func changeCWD(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var path string
 	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "path", &path); err != nil {

--- a/lib/path/path_test.go
+++ b/lib/path/path_test.go
@@ -170,6 +170,48 @@ func TestLoadModule_Path(t *testing.T) {
 			`),
 		},
 		{
+			name: `lexical: basename invalid`,
+			script: `load('path', 'basename')
+basename(1)`,
+			wantErr: `path.basename: for parameter path: got int, want string`,
+		},
+		{
+			name: `lexical: normpath invalid`,
+			script: `load('path', 'normpath')
+normpath(1)`,
+			wantErr: `path.normpath: for parameter path: got int, want string`,
+		},
+		{
+			name: `lexical: split invalid`,
+			script: `load('path', 'split')
+split(1)`,
+			wantErr: `path.split: for parameter path: got int, want string`,
+		},
+		{
+			name: `lexical: splitext invalid`,
+			script: `load('path', 'splitext')
+splitext(1)`,
+			wantErr: `path.splitext: for parameter path: got int, want string`,
+		},
+		{
+			name: `lexical: isabs invalid`,
+			script: `load('path', 'isabs')
+isabs(1)`,
+			wantErr: `path.isabs: for parameter path: got int, want string`,
+		},
+		{
+			name: `lexical: expanduser invalid`,
+			script: `load('path', 'expanduser')
+expanduser(1)`,
+			wantErr: `path.expanduser: for parameter path: got int, want string`,
+		},
+		{
+			name: `lexical: relpath invalid`,
+			script: `load('path', 'relpath')
+relpath(1)`,
+			wantErr: `path.relpath: for parameter path: got int, want string`,
+		},
+		{
 			name: `lexical: relpath empty path`,
 			script: itn.HereDoc(`
 				load('path', 'relpath')

--- a/lib/path/path_test.go
+++ b/lib/path/path_test.go
@@ -65,32 +65,143 @@ func TestLoadModule_Path(t *testing.T) {
 			name: `join: partial empty`,
 			script: itn.HereDoc(`
 				load('path', 'join')
-				assert.eq(join("a", "", ""), "a")
-				assert.eq(join("a", "b", ""), "a/b")
+				# Python semantics: an empty component contributes a
+				# trailing separator instead of being dropped
+				assert.eq(join("a", "", ""), "a/")
+				assert.eq(join("a", "b", ""), "a/b/")
 				assert.eq(join("a", "", "c"), "a/c")
 				assert.eq(join("", "b", "c"), "b/c")
 			`),
-			skipWindows: true,
 		},
 		{
 			name: `join: relative path`,
 			script: itn.HereDoc(`
 				load('path', 'join')
-				assert.eq(join("a/b", "../../../xyz"), "../xyz")
-				assert.eq(join("a/b", "../../xyz"), "xyz")
+				# Python semantics: no lexical cleaning - ".." stays put
+				# (use normpath to collapse it)
+				assert.eq(join("a/b", "../../../xyz"), "a/b/../../../xyz")
+				assert.eq(join("a/b", "../../xyz"), "a/b/../../xyz")
 			`),
-			skipWindows: true,
 		},
 		{
 			name: `join: absolute path`,
 			script: itn.HereDoc(`
 				load('path', 'join')
 				assert.eq(join("/a100"), "/a100")
-				assert.eq(join("/a100", ""), "/a100")
+				assert.eq(join("/a100", ""), "/a100/")
 				assert.eq(join("/a100", "b"), "/a100/b")
 				assert.eq(join("/a100", "b", "c"), "/a100/b/c")
+				# an absolute component resets the result
+				assert.eq(join("a", "/b"), "/b")
+				assert.eq(join("a", "/b", "c"), "/b/c")
 			`),
-			skipWindows: true,
+		},
+		{
+			name: `lexical: basename and dirname`,
+			script: itn.HereDoc(`
+				load('path', 'basename', 'dirname')
+				assert.eq(basename('a/b/c.txt'), 'c.txt')
+				assert.eq(basename('a/b/'), '')
+				assert.eq(basename('plain'), 'plain')
+				assert.eq(basename('/'), '')
+				assert.eq(dirname('a/b/c.txt'), 'a/b')
+				assert.eq(dirname('a/b/'), 'a/b')
+				assert.eq(dirname('plain'), '')
+				assert.eq(dirname('/a'), '/')
+				assert.eq(dirname('//a'), '//')
+			`),
+		},
+		{
+			name: `lexical: normpath`,
+			script: itn.HereDoc(`
+				load('path', 'normpath')
+				assert.eq(normpath('a//b'), 'a/b')
+				assert.eq(normpath('a/./b'), 'a/b')
+				assert.eq(normpath('a/c/../b'), 'a/b')
+				assert.eq(normpath('../a'), '../a')
+				assert.eq(normpath('a/../../b'), '../b')
+				assert.eq(normpath('/a/../../b'), '/b')
+				assert.eq(normpath('//a'), '//a')
+				assert.eq(normpath('///a'), '/a')
+				assert.eq(normpath(''), '.')
+				assert.eq(normpath('a/b/'), 'a/b')
+			`),
+		},
+		{
+			name: `lexical: split and splitext`,
+			script: itn.HereDoc(`
+				load('path', 'split', 'splitext')
+				assert.eq(split('a/b/c.txt'), ('a/b', 'c.txt'))
+				assert.eq(split('/a'), ('/', 'a'))
+				assert.eq(split('a/b/'), ('a/b', ''))
+				assert.eq(split('plain'), ('', 'plain'))
+				assert.eq(splitext('a/b.tar.gz'), ('a/b.tar', '.gz'))
+				assert.eq(splitext('.bashrc'), ('.bashrc', ''))
+				assert.eq(splitext('a/.bashrc'), ('a/.bashrc', ''))
+				assert.eq(splitext('noext'), ('noext', ''))
+				assert.eq(splitext('a.b/c'), ('a.b/c', ''))
+			`),
+		},
+		{
+			name: `lexical: isabs`,
+			script: itn.HereDoc(`
+				load('path', 'isabs')
+				assert.true(isabs('/a/b'))
+				assert.true(not isabs('a/b'))
+				assert.true(not isabs(''))
+			`),
+		},
+		{
+			name: `lexical: relpath`,
+			script: itn.HereDoc(`
+				load('path', 'relpath')
+				assert.eq(relpath('/a/b/c', '/a'), 'b/c')
+				assert.eq(relpath('/a/b', '/a/b'), '.')
+				assert.eq(relpath('/a/b', '/a/c/d'), '../../b')
+				assert.eq(relpath('a/b', 'a'), 'b')
+				assert.eq(relpath('a/b'), 'a/b')
+			`),
+		},
+		{
+			name: `lexical: relpath mixed kinds`,
+			script: itn.HereDoc(`
+				load('path', 'relpath')
+				relpath('/a/b', 'c')
+			`),
+			wantErr: `path.relpath: cannot mix an absolute path with a relative start`,
+		},
+		{
+			name: `lexical: try_relpath`,
+			script: itn.HereDoc(`
+				load('path', 'try_relpath')
+				v, err = try_relpath('/a/b/c', '/a')
+				assert.eq(err, None)
+				assert.eq(v, 'b/c')
+				v2, err2 = try_relpath('/a', 'c')
+				assert.eq(v2, None)
+				assert.true('cannot mix' in err2)
+			`),
+		},
+		{
+			name: `try_abs`,
+			script: itn.HereDoc(`
+				load('path', 'try_abs')
+				v, err = try_abs('.')
+				assert.eq(err, None)
+				assert.true(len(v) > 0)
+			`),
+		},
+		{
+			name: `expanduser`,
+			script: itn.HereDoc(`
+				load('path', 'expanduser')
+				h = expanduser('~')
+				assert.true(h != '~')
+				hs = expanduser('~/x')
+				assert.true(hs.endswith('/x'))
+				assert.eq(expanduser('~user/x'), '~user/x')
+				assert.eq(expanduser('plain'), 'plain')
+			`),
 		},
 		{
 			name: `abs: no args`,

--- a/lib/path/path_test.go
+++ b/lib/path/path_test.go
@@ -125,6 +125,9 @@ func TestLoadModule_Path(t *testing.T) {
 				assert.eq(normpath('///a'), '/a')
 				assert.eq(normpath(''), '.')
 				assert.eq(normpath('a/b/'), 'a/b')
+				assert.eq(normpath('../../a'), '../../a')
+				assert.eq(normpath('/../a'), '/a')
+				assert.eq(normpath('.'), '.')
 			`),
 		},
 		{
@@ -140,6 +143,8 @@ func TestLoadModule_Path(t *testing.T) {
 				assert.eq(splitext('a/.bashrc'), ('a/.bashrc', ''))
 				assert.eq(splitext('noext'), ('noext', ''))
 				assert.eq(splitext('a.b/c'), ('a.b/c', ''))
+				assert.eq(splitext('..b'), ('..b', ''))
+				assert.eq(splitext('a/..'), ('a/..', ''))
 			`),
 		},
 		{
@@ -160,7 +165,17 @@ func TestLoadModule_Path(t *testing.T) {
 				assert.eq(relpath('/a/b', '/a/c/d'), '../../b')
 				assert.eq(relpath('a/b', 'a'), 'b')
 				assert.eq(relpath('a/b'), 'a/b')
+				assert.eq(relpath('a/b', ''), 'a/b')
+				assert.eq(relpath('./a/b', '.'), 'a/b')
 			`),
+		},
+		{
+			name: `lexical: relpath empty path`,
+			script: itn.HereDoc(`
+				load('path', 'relpath')
+				relpath('')
+			`),
+			wantErr: `path.relpath: no path specified`,
 		},
 		{
 			name: `lexical: relpath mixed kinds`,


### PR DESCRIPTION
## Why

`lib/path` was a Go `filepath`/`os` hybrid: `join` used `filepath.Join` (cleans `..`/`//`, drops empty parts, ignores absolute restarts, OS-specific separator) and every Python lexical tool was missing — no `basename`/`dirname`/`splitext`/`normpath`/`relpath` (Backlog **LET-03**). Scripts — and the models that write them — expect Python behavior.

## One rule

- **Lexical functions** use **Python `posixpath` semantics**: pure string work on `/`-separated paths, no implicit cleaning, identical on every OS.
- **Filesystem functions** (`abs`, `exists`, `listdir`, …) stay OS-native.

## What

- **`join` changes in place** to Python semantics (absolute component resets, empty component adds a trailing separator, no cleaning). The README carries a migration table; `normpath(join(...))` reproduces the old cleaned result. In-tree script usage of `join` was zero (verified during planning); the previous tests pinned `filepath` semantics and are updated — and no longer need `skipWindows`, since posix lexical results are OS-independent.
- **New lexical functions**, hand-written against CPython `posixpath` (the Go standard library cannot be delegated to — `filepath.Base("a/b/")` is `"b"` vs Python `""`, `Clean` is eager, `dirname("//a")` must keep `"//"`…): `basename`, `dirname`, `normpath`, `split`, `splitext`, `isabs`, `relpath`, `expanduser`.
- **`relpath` refuses to mix** absolute and relative inputs instead of silently depending on the process CWD (Python does exactly that); `try_relpath`/`try_abs` provide the `(value, error)` pair shape shared with json/csv/http.
- **LET-04 (docs-only)**: `chdir` mutates the **whole-process** working directory — package doc and README now say so loudly. A machine-level virtual cwd was deliberately rejected: only `path` would see it while `lib/file` kept resolving against the real CWD — a split-brain worse than the honest global mutation. Host runtimes already exclude `path` from restricted module sets.

## Behavior change

`join` results differ for the migration-table inputs (release notes will carry the table). Everything else is additive.

Refs: LET-03, LET-04

🤖 Generated with [Claude Code](https://claude.com/claude-code)