### PR TITLE
[fix] LET-17: lossless Unmarshal defaults — int ladder, uniform string-keyed dicts, cycle safety

### DIFF
--- a/dataconv/helper.go
+++ b/dataconv/helper.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"math"
 	"reflect"
 	"strings"
@@ -53,15 +52,6 @@ func MarshalStarlarkJSON(data starlark.Value, indent int) (string, error) {
 	v, err := Unmarshal(data)
 	if err != nil {
 		return emptyStr, err
-	}
-
-	// fix map[interface {}]interface {}
-	if m, ok := v.(map[interface{}]interface{}); ok {
-		mm := make(map[string]interface{})
-		for k, v := range m {
-			mm[fmt.Sprintf("%v", k)] = v
-		}
-		v = mm
 	}
 
 	// prepare json encoder

--- a/dataconv/helper_test.go
+++ b/dataconv/helper_test.go
@@ -1391,3 +1391,25 @@ func BenchmarkDecodeStarlarkJSON(b *testing.B) {
 		}
 	}
 }
+
+func TestMarshalStarlarkJSONLossless(t *testing.T) {
+	// big integers used to fail in dumps (while json.encode accepted them)
+	big1 := starlark.MakeInt64(1).Lsh(100)
+	if got, err := MarshalStarlarkJSON(big1, 0); err != nil {
+		t.Errorf("expected the big int to dump, got error: %v", err)
+	} else if got != "1267650600228229401496703205376" {
+		t.Errorf("unexpected dump of 1<<100: %s", got)
+	}
+
+	// nested non-string-key dicts used to fail: the old top-level-only
+	// stringification patch could not reach them
+	inner := starlark.NewDict(1)
+	_ = inner.SetKey(starlark.MakeInt(1), starlark.String("x"))
+	outer := starlark.NewDict(1)
+	_ = outer.SetKey(starlark.String("outer"), inner)
+	if got, err := MarshalStarlarkJSON(outer, 0); err != nil {
+		t.Errorf("expected the nested non-string-key dict to dump, got error: %v", err)
+	} else if got != `{"outer":{"1":"x"}}` {
+		t.Errorf("unexpected dump: %s", got)
+	}
+}

--- a/dataconv/interface.go
+++ b/dataconv/interface.go
@@ -10,6 +10,26 @@
 //	|  Value  | <---------- |  Value     | <---------------------- | String   |
 //	|         |  Unmarshal  |            |   UnmarshalStarlarkJSON |          |
 //	+---------+             +------------+                         +----------+
+//
+// Which function to use:
+//
+//   - Starlark value -> native Go value: Unmarshal. Ints stay platform int
+//     in range and degrade to uint64/*big.Int beyond it; dicts come back as
+//     map[string]interface{} with non-string keys stringified (JSON-ready).
+//   - Go value -> Starlark value: Marshal (common types only; package
+//     starlight wraps everything else).
+//   - Starlark value -> JSON text and back, via the Go shapes above:
+//     MarshalStarlarkJSON / UnmarshalStarlarkJSON. The decode direction
+//     applies TypeConvert heuristics (RFC3339-looking strings become time
+//     values, whole floats become ints).
+//   - Starlark value -> JSON text and back, staying inside Starlark types:
+//     EncodeStarlarkJSON / DecodeStarlarkJSON (the interpreter's own json
+//     encoder: big ints work, bytes/time are errors, no heuristics).
+//
+// The starlight convert package remains the third conversion surface used
+// by the Machine API itself (Run/Call results): its FromValue returns
+// int64-first integers and fidelity-preserving typed dict keys, where this
+// package prefers JSON-friendly shapes.
 package dataconv
 
 import "go.starlark.net/starlark"

--- a/dataconv/marshal.go
+++ b/dataconv/marshal.go
@@ -286,10 +286,10 @@ func unmarshalValue(x starlark.Value, visited map[starlark.Value]bool) (val inte
 		}
 		val = value
 	case *starlark.Set:
-		if visited, err = enter(v); err != nil {
-			return nil, err
-		}
-		defer delete(visited, v)
+		// sets cannot participate in cycles: their elements must be
+		// hashable, and every container that could lead back to the set
+		// (dict/list/set, or a tuple holding one) is unhashable - so no
+		// visited tracking is needed here
 		var (
 			i      int
 			setVal starlark.Value

--- a/dataconv/marshal.go
+++ b/dataconv/marshal.go
@@ -5,6 +5,7 @@ package dataconv
 import (
 	"errors"
 	"fmt"
+	"math/big"
 	"time"
 
 	"github.com/1set/starlight/convert"
@@ -114,9 +115,40 @@ func Marshal(data interface{}) (v starlark.Value, err error) {
 	return
 }
 
-// Unmarshal converts a starlark.Value into it's Golang counterpart, like FromValue() of package starlight does.
+// Unmarshal converts a starlark.Value into its Golang counterpart, like FromValue() of package starlight does.
+//
+// The contract:
+//   - Int values within the platform int range come back as int; larger
+//     values degrade losslessly to uint64 and then *big.Int (they used to
+//     be an error).
+//   - Dicts always come back as map[string]interface{}: string keys keep
+//     their value, any other hashable key is stringified via its Starlark
+//     representation (bool keys use json-style "true"/"false"), and a
+//     post-stringification collision is an error. This deliberately
+//     prefers JSON-friendly shapes over key fidelity; use starlight's
+//     FromValue for typed dict keys.
+//   - Cyclic values, direct or indirect, are reported as errors.
+//
 // It's the opposite of Marshal().
 func Unmarshal(x starlark.Value) (val interface{}, err error) {
+	return unmarshalValue(x, nil)
+}
+
+// unmarshalValue is Unmarshal's engine; visited tracks the mutable
+// containers (dict/list/set) on the current descent path so that cyclic
+// values - direct or indirect - are reported instead of overflowing the
+// stack. The map is allocated lazily on the first container.
+func unmarshalValue(x starlark.Value, visited map[starlark.Value]bool) (val interface{}, err error) {
+	enter := func(c starlark.Value) (map[starlark.Value]bool, error) {
+		if visited[c] {
+			return nil, fmt.Errorf("cyclic reference found")
+		}
+		if visited == nil {
+			visited = make(map[starlark.Value]bool)
+		}
+		visited[c] = true
+		return visited, nil
+	}
 	iterAttrs := func(v starlark.HasAttrs) (map[string]interface{}, error) {
 		jo := make(map[string]interface{})
 		for _, name := range v.AttrNames() {
@@ -124,7 +156,7 @@ func Unmarshal(x starlark.Value) (val interface{}, err error) {
 			if err != nil {
 				return nil, err
 			}
-			jo[name], err = Unmarshal(sv)
+			jo[name], err = unmarshalValue(sv, visited)
 			if err != nil {
 				return nil, err
 			}
@@ -147,9 +179,18 @@ func Unmarshal(x starlark.Value) (val interface{}, err error) {
 	case starlark.Bool:
 		val = v.Truth() == starlark.True
 	case starlark.Int:
+		// in-range values keep returning the platform int (the historical
+		// dynamic type, which downstream type assertions depend on); values
+		// beyond it used to be an error and now degrade losslessly through
+		// uint64 to *big.Int instead
 		var tmp int
-		err = starlark.AsInt(x, &tmp)
-		val = tmp
+		if errConv := starlark.AsInt(x, &tmp); errConv == nil {
+			val = tmp
+		} else if u, ok := v.Uint64(); ok {
+			val = u
+		} else {
+			val = new(big.Int).Set(v.BigInt())
+		}
 	case starlark.Float:
 		if f, ok := starlark.AsFloat(x); !ok {
 			err = fmt.Errorf("couldn't parse float")
@@ -163,66 +204,52 @@ func Unmarshal(x starlark.Value) (val interface{}, err error) {
 	case startime.Time:
 		val = time.Time(v)
 	case *starlark.Dict:
-		var (
-			dictVal starlark.Value
-			pval    interface{}
-			kval    interface{}
-			keys    []interface{}
-			vals    []interface{}
-			// use interface{} as key type if found one key is not a string
-			keyIf bool
-		)
+		if visited, err = enter(v); err != nil {
+			return nil, err
+		}
+		defer delete(visited, v)
+		// the result is uniformly map[string]interface{} (JSON-marshalable):
+		// string keys keep their value, every other hashable key uses its
+		// Starlark representation. The old behavior flipped the whole map to
+		// map[interface{}]interface{} on the first non-string key - which
+		// json.Marshal rejects - and crashed the host outright on a tuple
+		// key. A post-stringification collision is reported instead of
+		// silently dropping an entry.
+		rs := make(map[string]interface{}, v.Len())
 		for _, k := range v.Keys() {
-			dictVal, _, err = v.Get(k)
-			if err != nil {
-				return
+			dictVal, _, errGet := v.Get(k)
+			if errGet != nil {
+				return nil, errGet
 			}
-
-			// check for cyclic reference
-			if dictVal == x {
-				err = fmt.Errorf("cyclic reference found")
-				return
+			pval, errVal := unmarshalValue(dictVal, visited)
+			if errVal != nil {
+				return nil, fmt.Errorf("unmarshaling starlark value: %w", errVal)
 			}
-
-			pval, err = Unmarshal(dictVal)
-			if err != nil {
-				err = fmt.Errorf("unmarshaling starlark value: %w", err)
-				return
+			var ks string
+			switch kk := k.(type) {
+			case starlark.String:
+				ks = kk.GoString()
+			case starlark.Bool:
+				// json-style lowercase, matching the historical dumps output
+				if bool(kk) {
+					ks = "true"
+				} else {
+					ks = "false"
+				}
+			default:
+				ks = kk.String()
 			}
-
-			kval, err = Unmarshal(k)
-			if err != nil {
-				err = fmt.Errorf("unmarshaling starlark key: %w", err)
-				return
+			if _, dup := rs[ks]; dup {
+				return nil, fmt.Errorf("dict key collision after stringification: %q", ks)
 			}
-
-			if _, ok := kval.(string); !ok {
-				// found key as not a string
-				keyIf = true
-			}
-
-			keys = append(keys, kval)
-			vals = append(vals, pval)
+			rs[ks] = pval
 		}
-
-		// prepare result
-		rs := map[string]interface{}{}
-		ri := map[interface{}]interface{}{}
-		for i, key := range keys {
-			// key as interface
-			if keyIf {
-				ri[key] = vals[i]
-			} else {
-				rs[key.(string)] = vals[i]
-			}
-		}
-
-		if keyIf {
-			val = ri // map[interface{}]interface{}
-		} else {
-			val = rs // map[string]interface{}
-		}
+		val = rs
 	case *starlark.List:
+		if visited, err = enter(v); err != nil {
+			return nil, err
+		}
+		defer delete(visited, v)
 		var (
 			i       int
 			listVal starlark.Value
@@ -232,11 +259,7 @@ func Unmarshal(x starlark.Value) (val interface{}, err error) {
 
 		defer iter.Done()
 		for iter.Next(&listVal) {
-			if listVal == x {
-				err = fmt.Errorf("cyclic reference found")
-				return
-			}
-			value[i], err = Unmarshal(listVal)
+			value[i], err = unmarshalValue(listVal, visited)
 			if err != nil {
 				return
 			}
@@ -253,7 +276,9 @@ func Unmarshal(x starlark.Value) (val interface{}, err error) {
 
 		defer iter.Done()
 		for iter.Next(&tupleVal) {
-			value[i], err = Unmarshal(tupleVal)
+			// tuples are immutable and cannot contain themselves, so they
+			// are not tracked in visited - their elements still are
+			value[i], err = unmarshalValue(tupleVal, visited)
 			if err != nil {
 				return
 			}
@@ -261,6 +286,10 @@ func Unmarshal(x starlark.Value) (val interface{}, err error) {
 		}
 		val = value
 	case *starlark.Set:
+		if visited, err = enter(v); err != nil {
+			return nil, err
+		}
+		defer delete(visited, v)
 		var (
 			i      int
 			setVal starlark.Value
@@ -270,7 +299,7 @@ func Unmarshal(x starlark.Value) (val interface{}, err error) {
 
 		defer iter.Done()
 		for iter.Next(&setVal) {
-			value[i], err = Unmarshal(setVal)
+			value[i], err = unmarshalValue(setVal, visited)
 			if err != nil {
 				return
 			}

--- a/dataconv/marshal_test.go
+++ b/dataconv/marshal_test.go
@@ -599,6 +599,23 @@ func TestUnmarshalLosslessContract(t *testing.T) {
 		t.Errorf("expected a key-collision error, got: %v", err)
 	}
 
+	// bool keys keep the historical json-style lowercase text
+	bd := starlark.NewDict(2)
+	_ = bd.SetKey(starlark.Bool(true), starlark.MakeInt(1))
+	_ = bd.SetKey(starlark.Bool(false), starlark.MakeInt(2))
+	if v, err := Unmarshal(bd); err != nil {
+		t.Errorf("expected the bool-key dict to unmarshal, got: %v", err)
+	} else if m := v.(map[string]interface{}); m["true"] != 1 || m["false"] != 2 {
+		t.Errorf("expected json-style bool keys, got %v", m)
+	}
+
+	// a list directly containing itself errors at the list's own guard
+	selfList := starlark.NewList(nil)
+	_ = selfList.Append(selfList)
+	if _, err := Unmarshal(selfList); err == nil || !strings.Contains(err.Error(), "cyclic reference") {
+		t.Errorf("expected a cyclic-reference error for the self-list, got: %v", err)
+	}
+
 	// an indirect cycle (dict -> list -> dict) used to overflow the stack:
 	// the old detection only caught a container directly containing itself
 	cl := starlark.NewList(nil)

--- a/dataconv/marshal_test.go
+++ b/dataconv/marshal_test.go
@@ -3,6 +3,7 @@ package dataconv
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"reflect"
 	"strconv"
 	"strings"
@@ -256,7 +257,10 @@ func TestUnmarshal(t *testing.T) {
 		{startime.Time(now), now, ""},
 		{starlark.NewList([]starlark.Value{starlark.MakeInt(42)}), []interface{}{42}, ""},
 		{strDict, map[string]interface{}{"foo": 42}, ""},
-		{intDict, map[interface{}]interface{}{42 * 2: 42}, ""},
+		// non-string keys are stringified: the whole map stays
+		// map[string]interface{} instead of flipping to
+		// map[interface{}]interface{} on the first non-string key
+		{intDict, map[string]interface{}{"84": 42}, ""},
 		{ct, &customType{42}, ""},
 		{act, &customType{43}, ""},
 		{strDictCT, map[string]interface{}{"foo": 42, "bar": &customType{42}}, ""},
@@ -288,7 +292,10 @@ func TestUnmarshal(t *testing.T) {
 		{sse, nil, "unrecognized starlark type: *starlark.Builtin"},
 		{sle, nil, "unrecognized starlark type: *starlark.Builtin"},
 		{ste, nil, "unrecognized starlark type: *starlark.Builtin"},
-		{sdke, nil, "unmarshaling starlark key: unrecognized starlark type: *starlark.Builtin"},
+		// hashable non-string keys no longer go through Unmarshal: they are
+		// stringified via their Starlark representation, so a builtin key
+		// succeeds instead of erroring
+		{sdke, map[string]interface{}{"<built-in function foo>": 42}, ""},
 		{sdve, nil, "unmarshaling starlark value: unrecognized starlark type: *starlark.Builtin"},
 	}
 	for i, c := range cases {
@@ -553,5 +560,61 @@ func TestStructGoJSONMarshal(t *testing.T) {
 		return
 	} else if exp := `{"Name":"simple","Members":{"bar":{},"foo":"baz","now":{}}}`; string(got) != exp {
 		t.Logf("expected: %q, got: %q", exp, string(got))
+	}
+}
+
+func TestUnmarshalLosslessContract(t *testing.T) {
+	// ints beyond the platform int used to error; they now degrade
+	// losslessly through uint64 to *big.Int (in-range stays int)
+	huge := starlark.MakeInt64(1).Lsh(70)   // 1 << 70: beyond uint64, lands in *big.Int
+	overInt := starlark.MakeUint64(1 << 63) // beyond int64, fits uint64
+	if v, err := Unmarshal(overInt); err != nil {
+		t.Errorf("expected the uint64-range int to unmarshal, got error: %v", err)
+	} else if u, ok := v.(uint64); !ok || u != 1<<63 {
+		t.Errorf("expected uint64(1<<63), got %T %v", v, v)
+	}
+	if v, err := Unmarshal(huge); err != nil {
+		t.Errorf("expected the big int to unmarshal, got error: %v", err)
+	} else if b, ok := v.(*big.Int); !ok || b.BitLen() != 71 {
+		t.Errorf("expected *big.Int of 71 bits, got %T %v", v, v)
+	}
+
+	// a tuple key used to crash the host with 'hash of unhashable type';
+	// it is now stringified like any other non-string key
+	td := starlark.NewDict(1)
+	if err := td.SetKey(starlark.Tuple{starlark.String("a"), starlark.MakeInt(1)}, starlark.String("v")); err != nil {
+		t.Fatal(err)
+	}
+	if v, err := Unmarshal(td); err != nil {
+		t.Errorf("expected the tuple-key dict to unmarshal, got error: %v", err)
+	} else if m, ok := v.(map[string]interface{}); !ok || m[`("a", 1)`] != "v" {
+		t.Errorf("expected the tuple key to stringify, got %T %v", v, v)
+	}
+
+	// a post-stringification collision errors instead of dropping a value
+	cd := starlark.NewDict(2)
+	_ = cd.SetKey(starlark.MakeInt(1), starlark.String("a"))
+	_ = cd.SetKey(starlark.String("1"), starlark.String("b"))
+	if _, err := Unmarshal(cd); err == nil || !strings.Contains(err.Error(), "key collision") {
+		t.Errorf("expected a key-collision error, got: %v", err)
+	}
+
+	// an indirect cycle (dict -> list -> dict) used to overflow the stack:
+	// the old detection only caught a container directly containing itself
+	cl := starlark.NewList(nil)
+	cdict := starlark.NewDict(1)
+	_ = cdict.SetKey(starlark.String("l"), cl)
+	_ = cl.Append(cdict)
+	if _, err := Unmarshal(cdict); err == nil || !strings.Contains(err.Error(), "cyclic reference") {
+		t.Errorf("expected a cyclic-reference error, got: %v", err)
+	}
+
+	// the same container appearing twice WITHOUT a cycle is fine
+	shared := starlark.NewList([]starlark.Value{starlark.MakeInt(1)})
+	dd := starlark.NewDict(2)
+	_ = dd.SetKey(starlark.String("a"), shared)
+	_ = dd.SetKey(starlark.String("b"), shared)
+	if _, err := Unmarshal(dd); err != nil {
+		t.Errorf("expected the diamond-shaped value to unmarshal, got: %v", err)
 	}
 }

--- a/dataconv/types/many_test.go
+++ b/dataconv/types/many_test.go
@@ -441,3 +441,165 @@ func TestOneOrMany_UnpackArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestOneOrMany_StringVsValue(t *testing.T) {
+	// Create a list of strings
+	strList := starlark.NewList([]starlark.Value{
+		starlark.String("abc"),
+		starlark.String("def"),
+	})
+
+	// Test OneOrMany[starlark.String]
+	t.Run("OneOrMany[starlark.String]", func(t *testing.T) {
+		target := NewOneOrManyNoDefault[starlark.String]()
+		err := target.Unpack(strList)
+		if err != nil {
+			t.Errorf("OneOrMany[starlark.String].Unpack() error = %v", err)
+			return
+		}
+
+		expected := []starlark.String{starlark.String("abc"), starlark.String("def")}
+		if !reflect.DeepEqual(target.Slice(), expected) {
+			t.Errorf("OneOrMany[starlark.String].Unpack() got = %v, want %v", target.Slice(), expected)
+		}
+
+		// Verify first element
+		if target.First() != starlark.String("abc") {
+			t.Errorf("OneOrMany[starlark.String].First() got = %v, want %v", target.First(), starlark.String("abc"))
+		}
+
+		// Verify length
+		if target.Len() != 2 {
+			t.Errorf("OneOrMany[starlark.String].Len() got = %v, want %v", target.Len(), 2)
+		}
+	})
+
+	// Test OneOrMany[starlark.Value]
+	t.Run("OneOrMany[starlark.Value]", func(t *testing.T) {
+		target := NewOneOrManyNoDefault[starlark.Value]()
+		err := target.Unpack(strList)
+		if err != nil {
+			t.Errorf("OneOrMany[starlark.Value].Unpack() error = %v", err)
+			return
+		}
+
+		// For starlark.Value type, the whole list is treated as a single value
+		values := target.Slice()
+		if len(values) != 1 {
+			t.Errorf("OneOrMany[starlark.Value].Unpack() got len = %v, want %v", len(values), 1)
+			return
+		}
+
+		// Verify the value is a list type
+		list, ok := values[0].(*starlark.List)
+		if !ok {
+			t.Errorf("OneOrMany[starlark.Value].Unpack() value is not starlark.List type, but %T", values[0])
+			return
+		}
+
+		// Verify list contents
+		if list.Len() != 2 {
+			t.Errorf("List length got = %v, want %v", list.Len(), 2)
+			return
+		}
+
+		v1, ok := starlark.AsString(list.Index(0))
+		if !ok || v1 != "abc" {
+			t.Errorf("First list element got = %v, want %v", v1, "abc")
+		}
+
+		v2, ok := starlark.AsString(list.Index(1))
+		if !ok || v2 != "def" {
+			t.Errorf("Second list element got = %v, want %v", v2, "def")
+		}
+
+		// Verify first element is the list itself
+		first, ok := target.First().(*starlark.List)
+		if !ok || first != list {
+			t.Errorf("OneOrMany[starlark.Value].First() result is not the expected list")
+		}
+	})
+
+	// Test unpacking a single string
+	t.Run("Single_String", func(t *testing.T) {
+		singleStr := starlark.String("xyz")
+
+		// For starlark.String type
+		stringTarget := NewOneOrManyNoDefault[starlark.String]()
+		if err := stringTarget.Unpack(singleStr); err != nil {
+			t.Errorf("OneOrMany[starlark.String].Unpack(single) error = %v", err)
+			return
+		}
+
+		if stringTarget.First() != starlark.String("xyz") {
+			t.Errorf("OneOrMany[starlark.String].First() got = %v, want %v",
+				stringTarget.First(), starlark.String("xyz"))
+		}
+
+		// For starlark.Value type
+		valueTarget := NewOneOrManyNoDefault[starlark.Value]()
+		if err := valueTarget.Unpack(singleStr); err != nil {
+			t.Errorf("OneOrMany[starlark.Value].Unpack(single) error = %v", err)
+			return
+		}
+
+		first, ok := valueTarget.First().(starlark.String)
+		if !ok || first != starlark.String("xyz") {
+			t.Errorf("OneOrMany[starlark.Value].First() got = %v, want %v",
+				valueTarget.First(), starlark.String("xyz"))
+		}
+	})
+
+	// Test UnpackArgs method differences
+	t.Run("UnpackArgs", func(t *testing.T) {
+		// For starlark.String type
+		stringTarget := NewOneOrManyNoDefault[starlark.String]()
+		if err := starlark.UnpackArgs("test", []starlark.Value{strList}, nil, "v?", stringTarget); err != nil {
+			t.Errorf("OneOrMany[starlark.String].UnpackArgs() error = %v", err)
+			return
+		}
+
+		expected := []starlark.String{starlark.String("abc"), starlark.String("def")}
+		if !reflect.DeepEqual(stringTarget.Slice(), expected) {
+			t.Errorf("OneOrMany[starlark.String].UnpackArgs() got = %v, want %v",
+				stringTarget.Slice(), expected)
+		}
+
+		// For starlark.Value type
+		valueTarget := NewOneOrManyNoDefault[starlark.Value]()
+		if err := starlark.UnpackArgs("test", []starlark.Value{strList}, nil, "v?", valueTarget); err != nil {
+			t.Errorf("OneOrMany[starlark.Value].UnpackArgs() error = %v", err)
+			return
+		}
+
+		values := valueTarget.Slice()
+		if len(values) != 1 {
+			t.Errorf("OneOrMany[starlark.Value].UnpackArgs() got len = %v, want %v",
+				len(values), 1)
+			return
+		}
+
+		// Verify first element is a list
+		list, ok := values[0].(*starlark.List)
+		if !ok {
+			t.Errorf("OneOrMany[starlark.Value].UnpackArgs() value is not starlark.List type, but %T", values[0])
+			return
+		}
+
+		// Verify list contents
+		if list.Len() != 2 {
+			t.Errorf("List length got = %v, want %v", list.Len(), 2)
+			return
+		}
+
+		v1, ok := starlark.AsString(list.Index(0))
+		if !ok || v1 != "abc" {
+			t.Errorf("First list element got = %v, want %v", v1, "abc")
+		}
+
+		v2, ok := starlark.AsString(list.Index(1))
+		if !ok || v2 != "def" {
+			t.Errorf("Second list element got = %v, want %v", v2, "def")
+		}
+	})
+}


### PR DESCRIPTION
## Why (Backlog LET-17 — and the user-set constraint: merge into the existing API, no third function set)

`Unmarshal` had three defects feeding every JSON-bound consumer:

1. `starlark.Int` beyond the platform `int` **errored** — `json.dumps(1<<70)` failed while `json.encode` accepted it (same module, opposite abilities).
2. A single non-string key flipped the whole dict to `map[interface{}]interface{}` (which `json.Marshal` rejects) — and a **tuple key crashed the host outright** (`hash of unhashable type` panic; an unregistered bug found during planning).
3. Cycle detection only caught a container *directly* containing itself; an indirect cycle (dict → list → dict) **overflowed the stack**.

## What — default-behavior upgrade, zero new functions

- **Int ladder (compatibility variant)**: in-range values keep returning `int` — the historical dynamic type that downstream type assertions depend on (a starlight-style int64-first ladder would silently break seven `.(int)` assertions in one downstream alone, verified across the workspace). Beyond-range values degrade losslessly: `uint64` → `*big.Int`. Every visible change on this axis is error→success.
- **Uniform string-keyed dicts**: always `map[string]interface{}`; non-string keys stringify via their Starlark representation (bool keys keep the historical json-style `true`/`false`); a post-stringification **collision errors** instead of silently dropping an entry. The tuple-key panic dies with this. `MarshalStarlarkJSON`'s top-level-only stringification patch became dead code and is removed — **nested** non-string-key dicts dump correctly for the first time.
- **Cycle safety**: a visited set travels the descent path; indirect cycles error cleanly; diamond-shaped sharing (same list referenced twice, no cycle) stays legal.
- **Docs**: the package doc gains a which-function-when matrix (Unmarshal/Marshal vs the two JSON layers vs starlight convert — the three int semantics were a standing source of confusion); Unmarshal's godoc states the contract. Deliberate divergence from starlight's fidelity-preserving `FromValue` is documented (this package prefers JSON-friendly shapes).

Also folds in `OneOrMany` unpacking tests recovered from an unmerged local branch (`dataconv/types`).

## Downstream verification

llm and mq — the most Unmarshal-sensitive consumers (one branches on both map types, the other strictly requires `map[string]interface{}`) — pass **both** baseline and `go mod edit -replace` legs with zero regressions.

## Behavior change

Host-visible: over-range ints error→value; non-string-key dicts `map[interface{}]interface{}`→`map[string]interface{}` (the previous shape was unusable for JSON anyway); tuple-key panic→value; three pre-existing test expectations updated accordingly.

Refs: LET-17

🤖 Generated with [Claude Code](https://claude.com/claude-code)