### PR TITLE
[feat] LET-18: DecodeStarlark — typed decoding with path-carrying errors

### DIFF
--- a/dataconv/decode.go
+++ b/dataconv/decode.go
@@ -1,0 +1,283 @@
+package dataconv
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"reflect"
+	"strings"
+	"time"
+
+	startime "go.starlark.net/lib/time"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+var (
+	timeType     = reflect.TypeOf(time.Time{})
+	bigIntType   = reflect.TypeOf(big.Int{})
+	starValueTyp = reflect.TypeOf((*starlark.Value)(nil)).Elem()
+)
+
+// DecodeStarlark decodes a Starlark value directly into a typed Go
+// destination, the way encoding/json.Unmarshal fills a struct: out must be
+// a non-nil pointer. It walks the starlark.Value itself rather than going
+// through Unmarshal's interface{} shapes, so type information (int width,
+// bytes vs string, tuples) is checked against the destination instead of
+// being collapsed, and every error names the path that failed (for
+// example: messages[2].role: got int, want string).
+//
+// Supported destinations: structs (fields matched by the tagName struct
+// tag, falling back to the field name; unknown source keys are ignored),
+// pointers (None decodes to nil, so *T distinguishes absent from zero),
+// slices (from list or tuple; []byte also accepts bytes), maps with string
+// keys, booleans, integers (with overflow checks), floats, strings,
+// time.Time, big.Int, starlark.Value (taken as-is), and interface{}
+// (filled with Unmarshal's shapes). Struct sources may be dicts,
+// starlarkstruct structs, or modules.
+func DecodeStarlark(v starlark.Value, out interface{}, tagName string) error {
+	rv := reflect.ValueOf(out)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return errors.New("decode destination must be a non-nil pointer")
+	}
+	if v == nil {
+		return errors.New("nil source value")
+	}
+	return decodeValue(v, rv.Elem(), tagName, "")
+}
+
+// DecodeJSONStarlark is DecodeStarlark with the "json" tag name, matching
+// the struct tags most API payload types already carry.
+func DecodeJSONStarlark(v starlark.Value, out interface{}) error {
+	return DecodeStarlark(v, out, "json")
+}
+
+func decodeValue(v starlark.Value, dst reflect.Value, tagName, path string) error {
+	at := func(format string, args ...interface{}) error {
+		p := path
+		if p == "" {
+			p = "value"
+		}
+		return fmt.Errorf("%s: %s", p, fmt.Sprintf(format, args...))
+	}
+
+	// pointer destinations: None becomes nil, anything else allocates and
+	// descends - this is how *T distinguishes absent from zero
+	if dst.Kind() == reflect.Ptr {
+		if v == starlark.None {
+			dst.Set(reflect.Zero(dst.Type()))
+			return nil
+		}
+		if dst.IsNil() {
+			dst.Set(reflect.New(dst.Type().Elem()))
+		}
+		return decodeValue(v, dst.Elem(), tagName, path)
+	}
+
+	// interface destinations
+	if dst.Kind() == reflect.Interface {
+		if dst.Type() == starValueTyp {
+			dst.Set(reflect.ValueOf(v))
+			return nil
+		}
+		if dst.NumMethod() == 0 {
+			gv, err := Unmarshal(v)
+			if err != nil {
+				return at("%v", err)
+			}
+			if gv == nil {
+				dst.Set(reflect.Zero(dst.Type()))
+			} else {
+				dst.Set(reflect.ValueOf(gv))
+			}
+			return nil
+		}
+		return at("unsupported destination interface %s", dst.Type())
+	}
+
+	// concrete special types before the kind switch
+	switch dst.Type() {
+	case timeType:
+		t, ok := v.(startime.Time)
+		if !ok {
+			return at("got %s, want time", v.Type())
+		}
+		dst.Set(reflect.ValueOf(time.Time(t)))
+		return nil
+	case bigIntType:
+		i, ok := v.(starlark.Int)
+		if !ok {
+			return at("got %s, want int", v.Type())
+		}
+		dst.Set(reflect.ValueOf(*new(big.Int).Set(i.BigInt())))
+		return nil
+	}
+
+	switch dst.Kind() {
+	case reflect.Bool:
+		b, ok := v.(starlark.Bool)
+		if !ok {
+			return at("got %s, want bool", v.Type())
+		}
+		dst.SetBool(bool(b))
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		i, ok := v.(starlark.Int)
+		if !ok {
+			return at("got %s, want int", v.Type())
+		}
+		i64, ok := i.Int64()
+		if !ok || dst.OverflowInt(i64) {
+			return at("value %s overflows %s", i.String(), dst.Type())
+		}
+		dst.SetInt(i64)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		i, ok := v.(starlark.Int)
+		if !ok {
+			return at("got %s, want int", v.Type())
+		}
+		u64, ok := i.Uint64()
+		if !ok || dst.OverflowUint(u64) {
+			return at("value %s overflows %s", i.String(), dst.Type())
+		}
+		dst.SetUint(u64)
+	case reflect.Float32, reflect.Float64:
+		f, ok := starlark.AsFloat(v)
+		if !ok {
+			return at("got %s, want float", v.Type())
+		}
+		if dst.OverflowFloat(f) {
+			return at("value %v overflows %s", f, dst.Type())
+		}
+		dst.SetFloat(f)
+	case reflect.String:
+		switch sv := v.(type) {
+		case starlark.String:
+			dst.SetString(sv.GoString())
+		case starlark.Bytes:
+			dst.SetString(string(sv))
+		default:
+			return at("got %s, want string", v.Type())
+		}
+	case reflect.Slice:
+		if dst.Type().Elem().Kind() == reflect.Uint8 {
+			if bs, ok := v.(starlark.Bytes); ok {
+				dst.SetBytes([]byte(bs))
+				return nil
+			}
+		}
+		seq, ok := v.(starlark.Sequence)
+		if !ok {
+			return at("got %s, want list or tuple", v.Type())
+		}
+		n := seq.Len()
+		out := reflect.MakeSlice(dst.Type(), n, n)
+		iter := seq.Iterate()
+		defer iter.Done()
+		var ev starlark.Value
+		for i := 0; iter.Next(&ev); i++ {
+			if err := decodeValue(ev, out.Index(i), tagName, fmt.Sprintf("%s[%d]", path, i)); err != nil {
+				return err
+			}
+		}
+		dst.Set(out)
+	case reflect.Map:
+		if dst.Type().Key().Kind() != reflect.String {
+			return at("unsupported map key type %s", dst.Type().Key())
+		}
+		d, ok := v.(*starlark.Dict)
+		if !ok {
+			return at("got %s, want dict", v.Type())
+		}
+		out := reflect.MakeMapWithSize(dst.Type(), d.Len())
+		for _, k := range d.Keys() {
+			ks, ok := k.(starlark.String)
+			if !ok {
+				return at("dict key %s is not a string", k.String())
+			}
+			mv, _, err := d.Get(k)
+			if err != nil {
+				return at("%v", err)
+			}
+			elem := reflect.New(dst.Type().Elem()).Elem()
+			if err := decodeValue(mv, elem, tagName, joinPath(path, ks.GoString())); err != nil {
+				return err
+			}
+			out.SetMapIndex(reflect.ValueOf(ks.GoString()).Convert(dst.Type().Key()), elem)
+		}
+		dst.Set(out)
+	case reflect.Struct:
+		get, srcDesc := structGetter(v)
+		if get == nil {
+			return at("got %s, want dict or struct", v.Type())
+		}
+		t := dst.Type()
+		for i := 0; i < t.NumField(); i++ {
+			f := t.Field(i)
+			if f.PkgPath != "" {
+				continue // unexported
+			}
+			name := f.Name
+			if tagName != "" {
+				if tag, ok := f.Tag.Lookup(tagName); ok {
+					base := strings.Split(tag, ",")[0]
+					if base == "-" {
+						continue
+					}
+					if base != "" {
+						name = base
+					}
+				}
+			}
+			fv, found, err := get(name)
+			if err != nil {
+				return at("reading %s of %s: %v", name, srcDesc, err)
+			}
+			if !found || fv == nil {
+				continue // absent: leave the zero value (use *T to detect)
+			}
+			if err := decodeValue(fv, dst.Field(i), tagName, joinPath(path, name)); err != nil {
+				return err
+			}
+		}
+	default:
+		return at("unsupported destination type %s", dst.Type())
+	}
+	return nil
+}
+
+// structGetter adapts the dict-like sources a struct can decode from.
+func structGetter(v starlark.Value) (func(name string) (starlark.Value, bool, error), string) {
+	switch src := v.(type) {
+	case *starlark.Dict:
+		return func(name string) (starlark.Value, bool, error) {
+			val, found, err := src.Get(starlark.String(name))
+			return val, found, err
+		}, "dict"
+	case *starlarkstruct.Struct:
+		return func(name string) (starlark.Value, bool, error) {
+			val, err := src.Attr(name)
+			if err != nil || val == nil {
+				// a missing attribute is "absent", not an error
+				return nil, false, nil
+			}
+			return val, true, nil
+		}, "struct"
+	case *starlarkstruct.Module:
+		return func(name string) (starlark.Value, bool, error) {
+			val, err := src.Attr(name)
+			if err != nil || val == nil {
+				return nil, false, nil
+			}
+			return val, true, nil
+		}, "module"
+	}
+	return nil, ""
+}
+
+// joinPath appends a field segment to an error path.
+func joinPath(path, seg string) string {
+	if path == "" {
+		return seg
+	}
+	return path + "." + seg
+}

--- a/dataconv/decode_test.go
+++ b/dataconv/decode_test.go
@@ -273,3 +273,48 @@ func TestDecodeStarlarkDestinationEdges(t *testing.T) {
 		t.Errorf("expected a struct-shape error, got: %v", err)
 	}
 }
+
+func TestDecodeStarlarkMoreArms(t *testing.T) {
+	// successful uint decode, and the non-int source arm
+	var u8 uint8
+	if err := DecodeJSONStarlark(starlark.MakeInt(7), &u8); err != nil || u8 != 7 {
+		t.Errorf("expected uint8(7), got %d / %v", u8, err)
+	}
+	if err := DecodeJSONStarlark(starlark.String("x"), &u8); err == nil || !strings.Contains(err.Error(), "want int") {
+		t.Errorf("expected a uint type error, got: %v", err)
+	}
+	// the non-float source arm
+	var f float64
+	if err := DecodeJSONStarlark(starlark.Bool(true), &f); err == nil || !strings.Contains(err.Error(), "want float") {
+		t.Errorf("expected a float type error, got: %v", err)
+	}
+	// interface{} destinations: None becomes nil, unsupported sources error
+	var any interface{} = 42
+	if err := DecodeJSONStarlark(starlark.None, &any); err != nil || any != nil {
+		t.Errorf("expected nil from None, got %v / %v", any, err)
+	}
+	if err := DecodeJSONStarlark(mockStarlarkBuiltin("nope"), &any); err == nil {
+		t.Errorf("expected an error for a builtin into interface{}")
+	}
+	// a non-empty interface destination is rejected
+	var er error
+	if err := DecodeJSONStarlark(starlark.MakeInt(1), &er); err == nil || !strings.Contains(err.Error(), "unsupported destination interface") {
+		t.Errorf("expected an interface-destination error, got: %v", err)
+	}
+	// unexported struct fields are skipped, absent source attributes stay zero
+	type mixed struct {
+		Seen    int `json:"seen"`
+		Missing int `json:"missing"`
+		hidden  int
+	}
+	st := starlarkstruct.FromStringDict(starlarkstruct.Default, starlark.StringDict{"seen": starlark.MakeInt(1)})
+	var mx mixed
+	if err := DecodeJSONStarlark(st, &mx); err != nil || mx.Seen != 1 || mx.Missing != 0 || mx.hidden != 0 {
+		t.Errorf("unexpected mixed decode: %+v / %v", mx, err)
+	}
+	mod := &starlarkstruct.Module{Name: "m", Members: starlark.StringDict{"seen": starlark.MakeInt(2)}}
+	var mx2 mixed
+	if err := DecodeJSONStarlark(mod, &mx2); err != nil || mx2.Seen != 2 || mx2.Missing != 0 {
+		t.Errorf("unexpected module decode: %+v / %v", mx2, err)
+	}
+}

--- a/dataconv/decode_test.go
+++ b/dataconv/decode_test.go
@@ -1,0 +1,275 @@
+package dataconv
+
+// Tests for DecodeStarlark/DecodeJSONStarlark: typed decoding from
+// Starlark values into Go destinations with path-carrying errors.
+//
+// Sections:
+//   1. happy path: full struct with tags, nesting, slices, maps, pointers
+//   2. type and overflow errors carry the failing path
+//   3. destination edge cases (bad out, interface, starlark.Value, bytes)
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	startime "go.starlark.net/lib/time"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+func mkDict(t *testing.T, pairs map[string]starlark.Value) *starlark.Dict {
+	t.Helper()
+	d := starlark.NewDict(len(pairs))
+	for k, v := range pairs {
+		if err := d.SetKey(starlark.String(k), v); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return d
+}
+
+func TestDecodeStarlarkHappyPath(t *testing.T) {
+	type message struct {
+		Role    string  `json:"role"`
+		Tokens  int     `json:"tokens"`
+		Score   float64 `json:"score"`
+		Hidden  string  `json:"-"`
+		NoTag   bool
+		Comment *string `json:"comment"`
+	}
+	type payload struct {
+		Name     string         `json:"name"`
+		Messages []message      `json:"messages"`
+		Extra    map[string]int `json:"extra"`
+		Origin   time.Time      `json:"origin"`
+		Big      big.Int        `json:"big"`
+		Raw      starlark.Value `json:"raw"`
+		Any      interface{}    `json:"any"`
+		Blob     []byte         `json:"blob"`
+		Pos      [0]int         `json:"-"`
+	}
+
+	cmt := "first"
+	origin := time.Date(2023, 1, 15, 12, 30, 45, 0, time.UTC)
+	msg1 := mkDict(t, map[string]starlark.Value{
+		"role":    starlark.String("user"),
+		"tokens":  starlark.MakeInt(42),
+		"score":   starlark.Float(0.5),
+		"NoTag":   starlark.Bool(true),
+		"comment": starlark.String(cmt),
+		"ignored": starlark.MakeInt(1), // unknown source keys are skipped
+	})
+	msg2 := mkDict(t, map[string]starlark.Value{
+		"role":    starlark.String("assistant"),
+		"tokens":  starlark.MakeInt(7),
+		"comment": starlark.None, // explicit None -> nil pointer
+	})
+	src := mkDict(t, map[string]starlark.Value{
+		"name":     starlark.String("conv"),
+		"messages": starlark.NewList([]starlark.Value{msg1, msg2}),
+		"extra":    mkDict(t, map[string]starlark.Value{"a": starlark.MakeInt(1)}),
+		"origin":   startime.Time(origin),
+		"big":      starlark.MakeInt64(1).Lsh(80),
+		"raw":      starlark.Tuple{starlark.MakeInt(1)},
+		"any":      starlark.MakeInt(5),
+		"blob":     starlark.Bytes("\x01\x02"),
+	})
+
+	var out payload
+	if err := DecodeJSONStarlark(src, &out); err != nil {
+		t.Fatalf("decode expects no error, got: %v", err)
+	}
+	if out.Name != "conv" || len(out.Messages) != 2 {
+		t.Fatalf("unexpected top level: %+v", out)
+	}
+	m1, m2 := out.Messages[0], out.Messages[1]
+	if m1.Role != "user" || m1.Tokens != 42 || m1.Score != 0.5 || !m1.NoTag || m1.Comment == nil || *m1.Comment != "first" {
+		t.Errorf("unexpected message 1: %+v", m1)
+	}
+	if m1.Hidden != "" {
+		t.Errorf("the '-' tagged field must not be filled, got %q", m1.Hidden)
+	}
+	if m2.Comment != nil {
+		t.Errorf("None must decode to a nil pointer, got %v", *m2.Comment)
+	}
+	if out.Extra["a"] != 1 {
+		t.Errorf("unexpected map: %v", out.Extra)
+	}
+	if !out.Origin.Equal(origin) {
+		t.Errorf("unexpected time: %v", out.Origin)
+	}
+	if out.Big.BitLen() != 81 {
+		t.Errorf("unexpected big int: %v", &out.Big)
+	}
+	if _, ok := out.Raw.(starlark.Tuple); !ok {
+		t.Errorf("starlark.Value field must take the value as-is, got %T", out.Raw)
+	}
+	if out.Any != 5 {
+		t.Errorf("interface{} field must reuse Unmarshal shapes, got %T %v", out.Any, out.Any)
+	}
+	if string(out.Blob) != "\x01\x02" {
+		t.Errorf("unexpected bytes: %v", out.Blob)
+	}
+}
+
+func TestDecodeStarlarkSources(t *testing.T) {
+	type opts struct {
+		Level int `json:"level"`
+	}
+	// starlarkstruct.Struct and Module sources work like dicts
+	st := starlarkstruct.FromStringDict(starlarkstruct.Default, starlark.StringDict{"level": starlark.MakeInt(3)})
+	var o1 opts
+	if err := DecodeJSONStarlark(st, &o1); err != nil || o1.Level != 3 {
+		t.Errorf("struct source: got %+v, err %v", o1, err)
+	}
+	mod := &starlarkstruct.Module{Name: "m", Members: starlark.StringDict{"level": starlark.MakeInt(4)}}
+	var o2 opts
+	if err := DecodeJSONStarlark(mod, &o2); err != nil || o2.Level != 4 {
+		t.Errorf("module source: got %+v, err %v", o2, err)
+	}
+	// a tuple decodes into a slice
+	var ints []int
+	if err := DecodeJSONStarlark(starlark.Tuple{starlark.MakeInt(1), starlark.MakeInt(2)}, &ints); err != nil || len(ints) != 2 || ints[1] != 2 {
+		t.Errorf("tuple source: got %v, err %v", ints, err)
+	}
+	// bytes decode into a string destination as raw bytes
+	var s string
+	if err := DecodeJSONStarlark(starlark.Bytes("raw"), &s); err != nil || s != "raw" {
+		t.Errorf("bytes->string: got %q, err %v", s, err)
+	}
+}
+
+func TestDecodeStarlarkErrorsCarryPath(t *testing.T) {
+	type message struct {
+		Role string `json:"role"`
+		N    int8   `json:"n"`
+	}
+	type payload struct {
+		Messages []message      `json:"messages"`
+		Extra    map[string]int `json:"extra"`
+	}
+	cases := []struct {
+		name string
+		src  *starlark.Dict
+		want string
+	}{
+		{
+			name: "wrong type deep in a list",
+			src: mkDict(t, map[string]starlark.Value{
+				"messages": starlark.NewList([]starlark.Value{
+					mkDict(t, map[string]starlark.Value{"role": starlark.String("ok")}),
+					mkDict(t, map[string]starlark.Value{"role": starlark.MakeInt(3)}),
+				}),
+			}),
+			want: "messages[1].role: got int, want string",
+		},
+		{
+			name: "overflow names the field",
+			src: mkDict(t, map[string]starlark.Value{
+				"messages": starlark.NewList([]starlark.Value{
+					mkDict(t, map[string]starlark.Value{"n": starlark.MakeInt(1000)}),
+				}),
+			}),
+			want: "messages[0].n: value 1000 overflows int8",
+		},
+		{
+			name: "map value error names the key",
+			src: mkDict(t, map[string]starlark.Value{
+				"extra": mkDict(t, map[string]starlark.Value{"k": starlark.String("x")}),
+			}),
+			want: "extra.k: got string, want int",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var out payload
+			err := DecodeJSONStarlark(c.src, &out)
+			if err == nil || !strings.Contains(err.Error(), c.want) {
+				t.Errorf("expected error containing %q, got: %v", c.want, err)
+			}
+		})
+	}
+}
+
+func TestDecodeStarlarkDestinationEdges(t *testing.T) {
+	// out must be a non-nil pointer
+	var i int
+	if err := DecodeJSONStarlark(starlark.MakeInt(1), i); err == nil {
+		t.Errorf("expected an error for a non-pointer destination")
+	}
+	var pi *int
+	if err := DecodeJSONStarlark(starlark.MakeInt(1), pi); err == nil {
+		t.Errorf("expected an error for a nil pointer destination")
+	}
+	// nil source
+	if err := DecodeJSONStarlark(nil, &i); err == nil {
+		t.Errorf("expected an error for a nil source")
+	}
+	// top-level scalar works
+	if err := DecodeJSONStarlark(starlark.MakeInt(9), &i); err != nil || i != 9 {
+		t.Errorf("expected 9, got %d / %v", i, err)
+	}
+	// unsupported destination kind
+	var ch chan int
+	if err := DecodeJSONStarlark(starlark.MakeInt(1), &ch); err == nil || !strings.Contains(err.Error(), "unsupported destination type") {
+		t.Errorf("expected an unsupported-type error, got: %v", err)
+	}
+	// wrong shapes for containers
+	var sl []int
+	if err := DecodeJSONStarlark(starlark.MakeInt(1), &sl); err == nil || !strings.Contains(err.Error(), "want list or tuple") {
+		t.Errorf("expected a list-shape error, got: %v", err)
+	}
+	var mp map[string]int
+	if err := DecodeJSONStarlark(starlark.MakeInt(1), &mp); err == nil || !strings.Contains(err.Error(), "want dict") {
+		t.Errorf("expected a dict-shape error, got: %v", err)
+	}
+	var mk map[int]int
+	if err := DecodeJSONStarlark(starlark.NewDict(0), &mk); err == nil || !strings.Contains(err.Error(), "unsupported map key type") {
+		t.Errorf("expected a map-key error, got: %v", err)
+	}
+	// non-string dict key into a string-keyed map
+	bad := starlark.NewDict(1)
+	_ = bad.SetKey(starlark.MakeInt(1), starlark.MakeInt(2))
+	var mo map[string]int
+	if err := DecodeJSONStarlark(bad, &mo); err == nil || !strings.Contains(err.Error(), "is not a string") {
+		t.Errorf("expected a key-type error, got: %v", err)
+	}
+	// uint overflow and negative
+	var u8 uint8
+	if err := DecodeJSONStarlark(starlark.MakeInt(300), &u8); err == nil || !strings.Contains(err.Error(), "overflows uint8") {
+		t.Errorf("expected a uint overflow error, got: %v", err)
+	}
+	if err := DecodeJSONStarlark(starlark.MakeInt(-1), &u8); err == nil {
+		t.Errorf("expected an error for a negative value into uint8")
+	}
+	// float from int, and float32 overflow
+	var f32 float32
+	if err := DecodeJSONStarlark(starlark.MakeInt(2), &f32); err != nil || f32 != 2 {
+		t.Errorf("expected 2.0, got %v / %v", f32, err)
+	}
+	if err := DecodeJSONStarlark(starlark.Float(1e300), &f32); err == nil || !strings.Contains(err.Error(), "overflows float32") {
+		t.Errorf("expected a float overflow error, got: %v", err)
+	}
+	// time and big from wrong types
+	var tt time.Time
+	if err := DecodeJSONStarlark(starlark.String("now"), &tt); err == nil || !strings.Contains(err.Error(), "want time") {
+		t.Errorf("expected a time-type error, got: %v", err)
+	}
+	var bi big.Int
+	if err := DecodeJSONStarlark(starlark.String("1"), &bi); err == nil || !strings.Contains(err.Error(), "want int") {
+		t.Errorf("expected a big-int-type error, got: %v", err)
+	}
+	// bool from wrong type
+	var b bool
+	if err := DecodeJSONStarlark(starlark.MakeInt(1), &b); err == nil || !strings.Contains(err.Error(), "want bool") {
+		t.Errorf("expected a bool-type error, got: %v", err)
+	}
+	// struct from a non-dict
+	type s struct{}
+	var so s
+	if err := DecodeJSONStarlark(starlark.MakeInt(1), &so); err == nil || !strings.Contains(err.Error(), "want dict or struct") {
+		t.Errorf("expected a struct-shape error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Why

Every downstream needing a typed Go struct from a Starlark value hand-rolls its own converter, each failing differently (Backlog **LET-18**): reflect-based with silent widening here, ok-pattern type assertions that silently drop mistyped fields there — one consumer carries an assertion that can never succeed against `Unmarshal`'s actual output, so the field silently stays zero — and per-field getters that cannot tell *wrong type* from *absent*.

## What

**`DecodeStarlark(v, out, tagName)`** — `encoding/json.Unmarshal`-style decoding into `&T`:

- Walks the `starlark.Value` **directly**, deliberately not via `Unmarshal`'s `interface{}` shapes (int width, bytes-vs-string and tuple identity are already collapsed there).
- **Every error names the failing path**: `messages[1].role: got int, want string`, `messages[0].n: value 1000 overflows int8`, `extra.k: got string, want int`.
- Structs match fields by struct tag (falling back to the field name; `-` skips; unknown source keys ignored); pointers make `*T` distinguish **absent from zero** (`None` → nil); slices accept list/tuple (`[]byte` also accepts bytes); string-keyed maps; ints/uints with overflow checks; floats (int accepted); `time.Time`; `big.Int`; `starlark.Value` taken as-is; `interface{}` filled with Unmarshal shapes. Struct sources: dicts, `starlarkstruct` structs, modules.
- `DecodeJSONStarlark(v, out)` = the `json"`-tag shorthand. Embedded anonymous fields and custom hooks are explicitly v2.

This is a **new capability dimension** (decode-into), not a third variant of the Unmarshal surface — pure additive, nothing existing changes.

Tests: a full happy-path payload (nesting, list-of-dicts, map, time, big.Int, raw `starlark.Value`, `interface{}`, bytes, `-` tag, None→nil pointer, unknown-key skip), three path-carrying error shapes, and ~15 destination/shape edge cases.

Refs: LET-18

🤖 Generated with [Claude Code](https://claude.com/claude-code)