### PR TITLE
[feat] LET-19: module capability metadata and fail-closed exclusion

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,6 +1,9 @@
 package starlet
 
 import (
+	"fmt"
+	"strings"
+
 	libatom "github.com/1set/starlet/lib/atom"
 	libb64 "github.com/1set/starlet/lib/base64"
 	libcsv "github.com/1set/starlet/lib/csv"
@@ -99,4 +102,124 @@ func EnableGlobalReassign() {
 // DisableGlobalReassign disables global reassignment in Starlark environments for loading modules.
 func DisableGlobalReassign() {
 	resolve.AllowGlobalReassign = false
+}
+
+// ModuleCapability is a bit set classifying what a builtin module can
+// touch on the host. Policy layers use it to derive module sets instead of
+// maintaining hand-written name lists that silently rot as modules are
+// added.
+type ModuleCapability uint
+
+const (
+	// CapLog marks modules that write to the host's logging or console
+	// facilities (including stderr helpers).
+	CapLog ModuleCapability = 1 << iota
+	// CapProcess marks modules that read or mutate process-level state:
+	// working directory, host identity, runtime information.
+	CapProcess
+	// CapFileSystem marks modules that read or write the real filesystem.
+	CapFileSystem
+	// CapNetwork marks modules that open network connections.
+	CapNetwork
+
+	// CapPure is the empty set: pure computation with no host effects.
+	CapPure ModuleCapability = 0
+)
+
+// Has reports whether c includes every capability in other.
+func (c ModuleCapability) Has(other ModuleCapability) bool {
+	return c&other == other
+}
+
+// Intersects reports whether c shares any capability with other.
+func (c ModuleCapability) Intersects(other ModuleCapability) bool {
+	return c&other != 0
+}
+
+// String returns a "+"-joined list of capability names, or "pure".
+func (c ModuleCapability) String() string {
+	if c == CapPure {
+		return "pure"
+	}
+	var parts []string
+	for _, e := range []struct {
+		bit  ModuleCapability
+		name string
+	}{
+		{CapLog, "log"},
+		{CapProcess, "process"},
+		{CapFileSystem, "filesystem"},
+		{CapNetwork, "network"},
+	} {
+		if c.Has(e.bit) {
+			parts = append(parts, e.name)
+		}
+	}
+	return strings.Join(parts, "+")
+}
+
+// builtinModuleCapabilities declares the capability set of every builtin
+// module. A test pins this map to the module registry, so adding a module
+// without classifying it fails the build bar.
+var builtinModuleCapabilities = map[string]ModuleCapability{
+	"atom":         CapPure,
+	"base64":       CapPure,
+	"csv":          CapPure,
+	"file":         CapFileSystem,
+	"go_idiomatic": CapLog | CapProcess, // eprint/pprint write the host's stderr; sleep/exit touch run control
+	"hashlib":      CapPure,
+	"http":         CapNetwork,
+	"json":         CapPure,
+	"log":          CapLog,
+	"math":         CapPure,
+	"net":          CapNetwork,
+	"path":         CapFileSystem | CapProcess, // listdir/mkdir touch the FS; chdir/getcwd the process CWD
+	"random":       CapPure,
+	"re":           CapPure,
+	"runtime":      CapProcess, // exposes host identity, directories, process info
+	"stats":        CapPure,
+	"string":       CapPure,
+	"struct":       CapPure,
+	"time":         CapPure,
+}
+
+// GetBuiltinModuleCapability returns the capability set of a builtin
+// module; ok is false for names that are not builtin modules.
+func GetBuiltinModuleCapability(name string) (cap ModuleCapability, ok bool) {
+	cap, ok = builtinModuleCapabilities[name]
+	return
+}
+
+// GetBuiltinModuleNamesExcluding returns all builtin module names except
+// the given ones. An unknown name in the exclusion list is an error -
+// fail-closed, because a typo in a denylist must not silently include the
+// module it meant to block.
+func GetBuiltinModuleNamesExcluding(excludes ...string) ([]string, error) {
+	ex := make(map[string]bool, len(excludes))
+	for _, e := range excludes {
+		if _, found := allBuiltinModules[e]; !found {
+			return nil, fmt.Errorf("unknown builtin module to exclude: %q", e)
+		}
+		ex[e] = true
+	}
+	var names []string
+	for _, n := range GetAllBuiltinModuleNames() {
+		if !ex[n] {
+			names = append(names, n)
+		}
+	}
+	return names, nil
+}
+
+// GetBuiltinModuleNamesWithoutCapabilities returns the builtin module
+// names whose capability sets share nothing with caps - e.g. passing
+// CapNetwork|CapFileSystem yields the modules that can touch neither.
+func GetBuiltinModuleNamesWithoutCapabilities(caps ModuleCapability) []string {
+	var names []string
+	for _, n := range GetAllBuiltinModuleNames() {
+		if !builtinModuleCapabilities[n].Intersects(caps) {
+			names = append(names, n)
+		}
+	}
+	return names
 }

--- a/module_test.go
+++ b/module_test.go
@@ -1284,3 +1284,79 @@ func TestWrapStructData_Edit(t *testing.T) {
 		}
 	}
 }
+
+func TestModuleCapabilities(t *testing.T) {
+	// the capability map must classify exactly the builtin registry:
+	// adding a module without declaring its capabilities fails here
+	names := starlet.GetAllBuiltinModuleNames()
+	for _, n := range names {
+		if _, ok := starlet.GetBuiltinModuleCapability(n); !ok {
+			t.Errorf("builtin module %q has no capability classification", n)
+		}
+	}
+	if _, ok := starlet.GetBuiltinModuleCapability("no_such_module"); ok {
+		t.Errorf("expected ok=false for an unknown module name")
+	}
+
+	// spot-check the classifications that drive policy decisions
+	for name, want := range map[string]starlet.ModuleCapability{
+		"http": starlet.CapNetwork,
+		"net":  starlet.CapNetwork,
+		"file": starlet.CapFileSystem,
+		"path": starlet.CapFileSystem | starlet.CapProcess,
+		"json": starlet.CapPure,
+		"log":  starlet.CapLog,
+	} {
+		if got, _ := starlet.GetBuiltinModuleCapability(name); got != want {
+			t.Errorf("capability of %q = %v, want %v", name, got, want)
+		}
+	}
+
+	// String renders readable sets
+	if s := starlet.CapPure.String(); s != "pure" {
+		t.Errorf("CapPure.String() = %q", s)
+	}
+	if s := (starlet.CapFileSystem | starlet.CapProcess).String(); s != "process+filesystem" {
+		t.Errorf("combined String() = %q", s)
+	}
+}
+
+func TestGetBuiltinModuleNamesExcluding(t *testing.T) {
+	all := starlet.GetAllBuiltinModuleNames()
+	got, err := starlet.GetBuiltinModuleNamesExcluding("http", "net")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if len(got) != len(all)-2 {
+		t.Errorf("expected %d names, got %d", len(all)-2, len(got))
+	}
+	for _, n := range got {
+		if n == "http" || n == "net" {
+			t.Errorf("excluded module %q leaked through", n)
+		}
+	}
+
+	// fail-closed: a typo must not silently include the module it meant
+	// to block
+	if _, err := starlet.GetBuiltinModuleNamesExcluding("htpp"); err == nil {
+		t.Errorf("expected an error for an unknown exclusion name")
+	}
+}
+
+func TestGetBuiltinModuleNamesWithoutCapabilities(t *testing.T) {
+	got := starlet.GetBuiltinModuleNamesWithoutCapabilities(starlet.CapNetwork | starlet.CapFileSystem)
+	for _, n := range got {
+		if n == "http" || n == "net" || n == "file" || n == "path" {
+			t.Errorf("module %q must be excluded by its capabilities", n)
+		}
+	}
+	found := map[string]bool{}
+	for _, n := range got {
+		found[n] = true
+	}
+	for _, want := range []string{"json", "string", "re", "math"} {
+		if !found[want] {
+			t.Errorf("expected pure module %q in the result", want)
+		}
+	}
+}


### PR DESCRIPTION
## Why

The builtin registry exposes nothing but names, so policy layers build module sets by **hand-subtracting name lists** — and such denylists rot silently: when a new module joins the registry, every stale list lets it straight into the "restricted" set (Backlog **LET-19**; the downstream safe-set-misses-net incident is exactly this failure mode, and downstream code currently self-enumerates with subtraction for lack of an API).

## What (pure additive)

- **`ModuleCapability`** bit set — `CapLog` / `CapProcess` / `CapFileSystem` / `CapNetwork`, with `CapPure` as the empty set — and a declared classification for **every** builtin module. A registry-completeness test makes adding an unclassified module fail the bar, so the metadata cannot rot.
- **`GetBuiltinModuleNamesExcluding(names...)`**: exclusion that **rejects unknown names** — fail-closed, because a typo in a denylist must not silently include the module it meant to block.
- **`GetBuiltinModuleNamesWithoutCapabilities(caps)`**: derive module sets from capabilities instead of name lists — e.g. `CapNetwork|CapFileSystem` yields every module that can touch neither.

Designed as the L2 footing for the L3 capability-gating work (the policy layer derives its restricted sets instead of maintaining subtraction lists).

Refs: LET-19

🤖 Generated with [Claude Code](https://claude.com/claude-code)