### PR TITLE
[feat] regex: Python-style regex module (RE2) with Match objects, flags, named groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Inspired by the [*Starlight*](https://github.com/starlight-go/starlight) and [*S
 | [`log`](/lib/log)                 | [![godoc](https://pkg.go.dev/badge/github.com/1set/starlet/lib/log.svg)](https://pkg.go.dev/github.com/1set/starlet/lib/log)                 | Functionality for logging messages at various severity levels |
 | [`path`](/lib/path)               | [![godoc](https://pkg.go.dev/badge/github.com/1set/starlet/lib/path.svg)](https://pkg.go.dev/github.com/1set/starlet/lib/path)               | Functions to manipulate directories and file paths            |
 | [`random`](/lib/random)           | [![godoc](https://pkg.go.dev/badge/github.com/1set/starlet/lib/random.svg)](https://pkg.go.dev/github.com/1set/starlet/lib/random)           | Functions to generate random values for various distributions |
-| [`re`](/lib/re)                   | [![godoc](https://pkg.go.dev/badge/github.com/1set/starlet/lib/re.svg)](https://pkg.go.dev/github.com/1set/starlet/lib/re)                   | Regular expression functions for Starlark                     |
+| [`re`](/lib/re)                   | [![godoc](https://pkg.go.dev/badge/github.com/1set/starlet/lib/re.svg)](https://pkg.go.dev/github.com/1set/starlet/lib/re)                   | Regular expression functions for Starlark (legacy, frozen)    |
+| [`regex`](/lib/regex)             | [![godoc](https://pkg.go.dev/badge/github.com/1set/starlet/lib/regex.svg)](https://pkg.go.dev/github.com/1set/starlet/lib/regex)             | Python-style regex (RE2) with Match objects, flags, named groups |
 | [`runtime`](/lib/runtime)         | [![godoc](https://pkg.go.dev/badge/github.com/1set/starlet/lib/runtime.svg)](https://pkg.go.dev/github.com/1set/starlet/lib/runtime)         | Provides Go and app runtime information                       |
 | [`string`](/lib/string)           | [![godoc](https://pkg.go.dev/badge/github.com/1set/starlet/lib/string.svg)](https://pkg.go.dev/github.com/1set/starlet/lib/string)           | Constants and functions to manipulate strings                 |
 
@@ -102,7 +103,7 @@ This may output:
 ```
 Starlark: Hello, Starlet!
 Go: Hello, Starlet!
-Modules: [atom base64 csv file go_idiomatic hashlib http json log math path random re runtime string struct time]
+Modules: [atom base64 csv file go_idiomatic hashlib http json log math net path random re regex runtime stats string struct time]
 ```
 
 Use CLI to interact with the read-eval-print loop (REPL):

--- a/config.go
+++ b/config.go
@@ -17,6 +17,7 @@ import (
 	libpath "github.com/1set/starlet/lib/path"
 	librand "github.com/1set/starlet/lib/random"
 	libre "github.com/1set/starlet/lib/re"
+	libregex "github.com/1set/starlet/lib/regex"
 	librt "github.com/1set/starlet/lib/runtime"
 	libstat "github.com/1set/starlet/lib/stats"
 	libstr "github.com/1set/starlet/lib/string"
@@ -47,21 +48,22 @@ var allBuiltinModules = ModuleLoaderMap{
 		}, nil
 	},
 	// add third-party modules
-	libatom.ModuleName: libatom.LoadModule,
-	libb64.ModuleName:  libb64.LoadModule,
-	libcsv.ModuleName:  libcsv.LoadModule,
-	libfile.ModuleName: libfile.LoadModule,
-	libhash.ModuleName: libhash.LoadModule,
-	libhttp.ModuleName: libhttp.LoadModule,
-	libnet.ModuleName:  libnet.LoadModule,
-	libjson.ModuleName: libjson.LoadModule,
-	liblog.ModuleName:  liblog.LoadModule,
-	libpath.ModuleName: libpath.LoadModule,
-	librand.ModuleName: librand.LoadModule,
-	libre.ModuleName:   libre.LoadModule,
-	librt.ModuleName:   librt.LoadModule,
-	libstr.ModuleName:  libstr.LoadModule,
-	libstat.ModuleName: libstat.LoadModule,
+	libatom.ModuleName:  libatom.LoadModule,
+	libb64.ModuleName:   libb64.LoadModule,
+	libcsv.ModuleName:   libcsv.LoadModule,
+	libfile.ModuleName:  libfile.LoadModule,
+	libhash.ModuleName:  libhash.LoadModule,
+	libhttp.ModuleName:  libhttp.LoadModule,
+	libnet.ModuleName:   libnet.LoadModule,
+	libjson.ModuleName:  libjson.LoadModule,
+	liblog.ModuleName:   liblog.LoadModule,
+	libpath.ModuleName:  libpath.LoadModule,
+	librand.ModuleName:  librand.LoadModule,
+	libre.ModuleName:    libre.LoadModule,
+	libregex.ModuleName: libregex.LoadModule,
+	librt.ModuleName:    librt.LoadModule,
+	libstr.ModuleName:   libstr.LoadModule,
+	libstat.ModuleName:  libstat.LoadModule,
 }
 
 // GetAllBuiltinModuleNames returns a list of all builtin module names.
@@ -176,6 +178,7 @@ var builtinModuleCapabilities = map[string]ModuleCapability{
 	"path":         CapFileSystem | CapProcess, // listdir/mkdir touch the FS; chdir/getcwd the process CWD
 	"random":       CapPure,
 	"re":           CapPure,
+	"regex":        CapPure,
 	"runtime":      CapProcess, // exposes host identity, directories, process info
 	"stats":        CapPure,
 	"string":       CapPure,

--- a/lib/regex/README.md
+++ b/lib/regex/README.md
@@ -1,0 +1,69 @@
+# regex
+
+`regex` provides regular expression functions for Starlark, a subset of [Python's **re** module](https://docs.python.org/3/library/re.html) backed by Go's [RE2 engine](https://golang.org/s/re2syntax).
+
+It is the successor to the legacy `re` module (which is frozen): `regex` adds **Match objects**, named-group extraction, the `IGNORECASE`/`MULTILINE`/`DOTALL` flags, `\1`/`\g<name>` replacement and function replacements, and the full `compile`/`fullmatch`/`finditer`/`subn`/`escape` surface.
+
+**Python re semantics subset (RE2 engine, no lookaround / no backreferences).** RE2 matches in linear time — no catastrophic backtracking / ReDoS — which suits running untrusted or LLM-generated scripts in a sandbox. Where RE2 genuinely differs from Python — lookahead/lookbehind (`(?=...)`, `(?<=...)`) and in-pattern backreferences (`\1`) — the pattern fails to **compile** with a clear error rather than silently misbehaving.
+
+## Functions
+
+| function | description |
+|---|---|
+| `compile(pattern, flags=0)` | compile a pattern into a `Pattern` object |
+| `search(pattern, string, flags=0)` | first match anywhere → `Match` or `None` |
+| `match(pattern, string, flags=0)` | match anchored at the **start** → `Match` or `None` |
+| `fullmatch(pattern, string, flags=0)` | match the **whole** string → `Match` or `None` |
+| `findall(pattern, string, flags=0)` | all matches as a tuple (Python group shaping, see below) |
+| `finditer(pattern, string, flags=0)` | a tuple of `Match` objects |
+| `sub(pattern, repl, string, count=0, flags=0)` | replace matches → string |
+| `subn(pattern, repl, string, count=0, flags=0)` | replace → `(string, count)` |
+| `split(pattern, string, maxsplit=0, flags=0)` | split, **including capture-group text** (Python semantics) |
+| `escape(pattern)` | escape regex metacharacters |
+
+`try_compile` / `try_search` are also provided, returning a `(value, error)` pair instead of aborting the script — the same shape as the `json`/`csv`/`http` modules.
+
+**findall shaping** (matches Python): no capture group → the full match text; one group → that group's text; two or more groups → a tuple of the group texts per match.
+
+**sub replacement**: `repl` is either a string template — `\1`/`\g<name>` reference capture groups, `\n`/`\t`/`\r` are the usual escapes, a literal `$` is preserved — or a function called with each `Match`, returning the replacement string. `count` limits the number of replacements (`0` = all, negative = none).
+
+## Flags
+
+`I`/`IGNORECASE`, `M`/`MULTILINE`, `S`/`DOTALL` — integer constants (Python's `re` values) that may be combined with `|` and translate to RE2 inline flags.
+
+```python
+load("regex", "search", "I")
+print(search("hello", "HELLO WORLD", I).group(0))
+# Output: "HELLO"
+```
+
+## Types
+
+### `Pattern`
+
+A compiled regular expression. Methods mirror the module functions without the `pattern` argument: `search`, `match`, `fullmatch`, `findall`, `finditer`, `sub`, `subn`, `split`. Attributes: `pattern` (the source), `flags`, `groups` (number of capture groups).
+
+### `Match`
+
+The result of a successful `search`/`match`/`fullmatch`.
+
+| member | description |
+|---|---|
+| `group(n=0, ...)` | group text by index or name; several args → a tuple; group 0 is the whole match |
+| `groups(default=None)` | a tuple of all capture groups (`default` for non-participating groups) |
+| `groupdict(default=None)` | a dict of named groups to their text |
+| `start(n=0)` / `end(n=0)` | start/end byte index of a group |
+| `span(n=0)` | `(start, end)` of a group |
+| `expand(template)` | apply a `\1`/`\g<name>` template against the match |
+| `string` | the subject string that was matched |
+| `re` | the `Pattern` that produced the match |
+
+A non-participating optional group reports `None`. `Match` objects are unhashable (they cannot be used as dict keys).
+
+```python
+load("regex", "search")
+m = search(r'(?P<user>\w+)@(?P<host>\w+)', 'ann@example.com')
+print(m.group('user'), m.group('host'))   # ann example
+print(m.groupdict())                       # {"user": "ann", "host": "example"}
+print(m.span(0))                           # (0, 11)
+```

--- a/lib/regex/regex.go
+++ b/lib/regex/regex.go
@@ -1,0 +1,797 @@
+// Package regex provides regular expression functions for Starlark, intended
+// as a subset of Python's re module backed by Go's RE2 engine.
+//
+// Python re semantics subset (RE2 engine, no lookaround / no backreferences).
+// RE2 guarantees linear-time matching — no catastrophic backtracking / ReDoS —
+// which suits running untrusted or LLM-generated scripts in a sandbox. Where
+// RE2 genuinely differs from Python (lookahead/lookbehind (?=...)/(?<=...) and
+// in-pattern backreferences \1), the pattern fails to compile with a clear
+// error instead of silently misbehaving. Shapes that DO align with Python —
+// Match objects, findall group tuples, sub's \1 / \g<name> replacement, the
+// IGNORECASE/MULTILINE/DOTALL flags — are matched faithfully.
+//
+// The legacy `re` module is frozen; new code should use this `regex` module.
+package regex
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+// ModuleName is the name under which the module is loaded, e.g. load('regex', 'compile').
+const ModuleName = "regex"
+
+// Flag values mirror Python's re.I / re.M / re.S so scripts can OR them; they
+// are translated to RE2 inline flags ((?i)(?m)(?s)) at compile time.
+const (
+	flagIgnoreCase = 2
+	flagMultiline  = 8
+	flagDotAll     = 16
+	flagsAll       = flagIgnoreCase | flagMultiline | flagDotAll
+)
+
+var (
+	once     sync.Once
+	regexMod starlark.StringDict
+)
+
+// LoadModule loads the regex module. It is concurrency-safe and idempotent.
+func LoadModule() (starlark.StringDict, error) {
+	once.Do(func() {
+		regexMod = starlark.StringDict{
+			ModuleName: &starlarkstruct.Module{
+				Name: ModuleName,
+				Members: starlark.StringDict{
+					"compile":     starlark.NewBuiltin(ModuleName+".compile", compile),
+					"try_compile": starlark.NewBuiltin(ModuleName+".try_compile", wrapTry(compile)),
+					"search":      starlark.NewBuiltin(ModuleName+".search", search),
+					"try_search":  starlark.NewBuiltin(ModuleName+".try_search", wrapTry(search)),
+					"match":       starlark.NewBuiltin(ModuleName+".match", match),
+					"fullmatch":   starlark.NewBuiltin(ModuleName+".fullmatch", fullmatch),
+					"findall":     starlark.NewBuiltin(ModuleName+".findall", findall),
+					"finditer":    starlark.NewBuiltin(ModuleName+".finditer", finditer),
+					"sub":         starlark.NewBuiltin(ModuleName+".sub", sub),
+					"subn":        starlark.NewBuiltin(ModuleName+".subn", subn),
+					"split":       starlark.NewBuiltin(ModuleName+".split", split),
+					"escape":      starlark.NewBuiltin(ModuleName+".escape", escape),
+					// flag constants (Python re values, OR-able)
+					"I":          starlark.MakeInt(flagIgnoreCase),
+					"IGNORECASE": starlark.MakeInt(flagIgnoreCase),
+					"M":          starlark.MakeInt(flagMultiline),
+					"MULTILINE":  starlark.MakeInt(flagMultiline),
+					"S":          starlark.MakeInt(flagDotAll),
+					"DOTALL":     starlark.MakeInt(flagDotAll),
+				},
+			},
+		}
+	})
+	return regexMod, nil
+}
+
+// builtinFn is the signature of a module-level builtin.
+type builtinFn func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error)
+
+// wrapTry converts a builtin into its try_ variant: a (value, error-string)
+// pair with a nil Go error, the shape shared by lib/json/csv/http.
+func wrapTry(fn builtinFn) builtinFn {
+	return func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		res, err := fn(thread, b, args, kwargs)
+		if err != nil {
+			return starlark.Tuple{starlark.None, starlark.String(err.Error())}, nil
+		}
+		if res == nil {
+			res = starlark.None
+		}
+		return starlark.Tuple{res, starlark.None}, nil
+	}
+}
+
+// flagsPrefix builds the RE2 inline-flag prefix for the given Python flags.
+func flagsPrefix(flags int) (string, error) {
+	if flags&^flagsAll != 0 {
+		return "", fmt.Errorf("unsupported flags value %d (only I/IGNORECASE, M/MULTILINE, S/DOTALL)", flags)
+	}
+	var f string
+	if flags&flagIgnoreCase != 0 {
+		f += "i"
+	}
+	if flags&flagMultiline != 0 {
+		f += "m"
+	}
+	if flags&flagDotAll != 0 {
+		f += "s"
+	}
+	if f == "" {
+		return "", nil
+	}
+	return "(?" + f + ")", nil
+}
+
+// compileFor compiles a pattern for the given match kind. kind controls
+// anchoring: "search" none, "match" anchors at the start (\A), "full" anchors
+// both ends (\A...\z). The flags become an inline prefix.
+func compileFor(pattern string, flags int, kind string) (*regexp.Regexp, error) {
+	prefix, err := flagsPrefix(flags)
+	if err != nil {
+		return nil, err
+	}
+	body := pattern
+	switch kind {
+	case "match":
+		body = `\A(?:` + pattern + `)`
+	case "full":
+		body = `\A(?:` + pattern + `)\z`
+	}
+	re, err := regexp.Compile(prefix + body)
+	if err != nil {
+		return nil, fmt.Errorf("cannot compile pattern: %w", err)
+	}
+	return re, nil
+}
+
+// ---- module-level functions ----
+
+func compile(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		pattern string
+		flags   int
+	)
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "pattern", &pattern, "flags?", &flags); err != nil {
+		return nil, err
+	}
+	return newPattern(pattern, flags)
+}
+
+func search(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	p, str, err := unpackPatternCall(b, args, kwargs)
+	if err != nil {
+		return nil, err
+	}
+	return p.doFind(str, "search"), nil
+}
+
+func match(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	p, str, err := unpackPatternCall(b, args, kwargs)
+	if err != nil {
+		return nil, err
+	}
+	return p.doFind(str, "match"), nil
+}
+
+func fullmatch(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	p, str, err := unpackPatternCall(b, args, kwargs)
+	if err != nil {
+		return nil, err
+	}
+	return p.doFind(str, "full"), nil
+}
+
+func findall(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	p, str, err := unpackPatternCall(b, args, kwargs)
+	if err != nil {
+		return nil, err
+	}
+	return p.doFindall(str), nil
+}
+
+func finditer(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	p, str, err := unpackPatternCall(b, args, kwargs)
+	if err != nil {
+		return nil, err
+	}
+	return p.doFinditer(str), nil
+}
+
+func split(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		pattern, str string
+		maxsplit     int
+		flags        int
+	)
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "pattern", &pattern, "string", &str, "maxsplit?", &maxsplit, "flags?", &flags); err != nil {
+		return nil, err
+	}
+	p, err := newPattern(pattern, flags)
+	if err != nil {
+		return nil, err
+	}
+	return p.doSplit(str, maxsplit), nil
+}
+
+func sub(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	pat, repl, str, count, flags, err := unpackSubCall(b, args, kwargs)
+	if err != nil {
+		return nil, err
+	}
+	p, err := newPattern(pat, flags)
+	if err != nil {
+		return nil, err
+	}
+	out, _, err := p.doSub(thread, repl, str, count)
+	if err != nil {
+		return nil, err
+	}
+	return starlark.String(out), nil
+}
+
+func subn(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	pat, repl, str, count, flags, err := unpackSubCall(b, args, kwargs)
+	if err != nil {
+		return nil, err
+	}
+	p, err := newPattern(pat, flags)
+	if err != nil {
+		return nil, err
+	}
+	out, n, err := p.doSub(thread, repl, str, count)
+	if err != nil {
+		return nil, err
+	}
+	return starlark.Tuple{starlark.String(out), starlark.MakeInt(n)}, nil
+}
+
+func escape(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var s string
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "pattern", &s); err != nil {
+		return nil, err
+	}
+	return starlark.String(regexp.QuoteMeta(s)), nil
+}
+
+// unpackPatternCall handles the (pattern, string, flags=0) argument form.
+func unpackPatternCall(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (*Pattern, string, error) {
+	var (
+		pattern, str string
+		flags        int
+	)
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "pattern", &pattern, "string", &str, "flags?", &flags); err != nil {
+		return nil, "", err
+	}
+	p, err := newPattern(pattern, flags)
+	if err != nil {
+		return nil, "", err
+	}
+	return p, str, nil
+}
+
+// unpackSubCall handles the (pattern, repl, string, count=0, flags=0) form.
+func unpackSubCall(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (pat string, repl starlark.Value, str string, count, flags int, err error) {
+	err = starlark.UnpackArgs(b.Name(), args, kwargs, "pattern", &pat, "repl", &repl, "string", &str, "count?", &count, "flags?", &flags)
+	return
+}
+
+// ---- Pattern type ----
+
+// Pattern is a compiled regular expression (the value returned by compile()).
+type Pattern struct {
+	pattern string
+	flags   int
+	search  *regexp.Regexp // unanchored
+	mat     *regexp.Regexp // \A-anchored
+	full    *regexp.Regexp // \A...\z-anchored
+}
+
+func newPattern(pattern string, flags int) (*Pattern, error) {
+	s, err := compileFor(pattern, flags, "search")
+	if err != nil {
+		return nil, err
+	}
+	m, err := compileFor(pattern, flags, "match")
+	if err != nil {
+		return nil, err
+	}
+	f, err := compileFor(pattern, flags, "full")
+	if err != nil {
+		return nil, err
+	}
+	return &Pattern{pattern: pattern, flags: flags, search: s, mat: m, full: f}, nil
+}
+
+func (p *Pattern) reFor(kind string) *regexp.Regexp {
+	switch kind {
+	case "match":
+		return p.mat
+	case "full":
+		return p.full
+	default:
+		return p.search
+	}
+}
+
+// doFind runs a single match and returns a Match value or None.
+func (p *Pattern) doFind(str, kind string) starlark.Value {
+	re := p.reFor(kind)
+	loc := re.FindStringSubmatchIndex(str)
+	if loc == nil {
+		return starlark.None
+	}
+	return &Match{p: p, str: str, loc: loc}
+}
+
+// doFindall implements Python findall shaping: no group -> the full matches;
+// one group -> that group's text; several groups -> a tuple per match.
+func (p *Pattern) doFindall(str string) starlark.Value {
+	ng := p.search.NumSubexp()
+	var out starlark.Tuple
+	for _, m := range p.search.FindAllStringSubmatchIndex(str, -1) {
+		switch ng {
+		case 0:
+			out = append(out, starlark.String(str[m[0]:m[1]]))
+		case 1:
+			out = append(out, groupText(str, m, 1))
+		default:
+			var grp starlark.Tuple
+			for g := 1; g <= ng; g++ {
+				grp = append(grp, groupText(str, m, g))
+			}
+			out = append(out, grp)
+		}
+	}
+	return out
+}
+
+func (p *Pattern) doFinditer(str string) starlark.Value {
+	var out starlark.Tuple
+	for _, m := range p.search.FindAllStringSubmatchIndex(str, -1) {
+		loc := make([]int, len(m))
+		copy(loc, m)
+		out = append(out, &Match{p: p, str: str, loc: loc})
+	}
+	return out
+}
+
+// doSplit implements Python split: the text of capture groups is included in
+// the result. A non-positive maxsplit means no limit.
+func (p *Pattern) doSplit(str string, maxsplit int) starlark.Value {
+	ng := p.search.NumSubexp()
+	var out starlark.Tuple
+	last := 0
+	n := 0
+	for _, m := range p.search.FindAllStringSubmatchIndex(str, -1) {
+		if maxsplit > 0 && n >= maxsplit {
+			break
+		}
+		out = append(out, starlark.String(str[last:m[0]]))
+		for g := 1; g <= ng; g++ {
+			out = append(out, groupText(str, m, g))
+		}
+		last = m[1]
+		n++
+	}
+	out = append(out, starlark.String(str[last:]))
+	return out
+}
+
+// doSub replaces matches. repl is either a string template (Python \1 /
+// \g<name> translated to Go's $-syntax) or a callable invoked per Match.
+func (p *Pattern) doSub(thread *starlark.Thread, repl starlark.Value, str string, count int) (string, int, error) {
+	var (
+		tmpl     string
+		callable starlark.Callable
+	)
+	switch r := repl.(type) {
+	case starlark.String:
+		tmpl = translateRepl(r.GoString())
+	case starlark.Callable:
+		callable = r
+	default:
+		return "", 0, fmt.Errorf("repl must be a string or a function, got %s", repl.Type())
+	}
+
+	if count < 0 {
+		// Python: a negative count replaces nothing
+		return str, 0, nil
+	}
+	limit := -1
+	if count > 0 {
+		limit = count
+	}
+
+	var b []byte
+	last := 0
+	n := 0
+	for _, m := range p.search.FindAllStringSubmatchIndex(str, limit) {
+		b = append(b, str[last:m[0]]...)
+		if callable != nil {
+			rv, err := starlark.Call(thread, callable, starlark.Tuple{&Match{p: p, str: str, loc: append([]int(nil), m...)}}, nil)
+			if err != nil {
+				return "", 0, err
+			}
+			rs, ok := starlark.AsString(rv)
+			if !ok {
+				return "", 0, fmt.Errorf("repl function must return a string, got %s", rv.Type())
+			}
+			b = append(b, rs...)
+		} else {
+			b = p.search.ExpandString(b, tmpl, str, m)
+		}
+		last = m[1]
+		n++
+	}
+	b = append(b, str[last:]...)
+	return string(b), n, nil
+}
+
+// translateRepl converts a Python replacement template to Go's ExpandString
+// syntax: \1 -> ${1}, \g<name> -> ${name}, and a literal $ is escaped to $$.
+func translateRepl(r string) string {
+	var b strings.Builder
+	rs := []rune(r)
+	for i := 0; i < len(rs); i++ {
+		switch {
+		case rs[i] == '$':
+			b.WriteString("$$")
+		case rs[i] == '\\' && i+1 < len(rs):
+			next := rs[i+1]
+			switch {
+			case next >= '0' && next <= '9':
+				b.WriteString("${" + string(next) + "}")
+				i++
+			case next == 'g' && i+2 < len(rs) && rs[i+2] == '<':
+				j := i + 3
+				for j < len(rs) && rs[j] != '>' {
+					j++
+				}
+				if j < len(rs) {
+					b.WriteString("${" + string(rs[i+3:j]) + "}")
+					i = j
+				} else {
+					b.WriteRune(rs[i])
+				}
+			case next == '\\':
+				b.WriteByte('\\')
+				i++
+			case next == 'n':
+				b.WriteByte('\n')
+				i++
+			case next == 't':
+				b.WriteByte('\t')
+				i++
+			case next == 'r':
+				b.WriteByte('\r')
+				i++
+			default:
+				b.WriteRune(rs[i])
+			}
+		default:
+			b.WriteRune(rs[i])
+		}
+	}
+	return b.String()
+}
+
+// groupText returns the text of capture group g for a submatch index slice,
+// or None if the group did not participate.
+func groupText(str string, loc []int, g int) starlark.Value {
+	if 2*g+1 >= len(loc) || loc[2*g] < 0 {
+		return starlark.None
+	}
+	return starlark.String(str[loc[2*g]:loc[2*g+1]])
+}
+
+// starlark.Value implementation for Pattern.
+
+func (p *Pattern) String() string        { return fmt.Sprintf("regex.compile(%q)", p.pattern) }
+func (p *Pattern) Type() string          { return "regex.Pattern" }
+func (p *Pattern) Freeze()               {}
+func (p *Pattern) Truth() starlark.Bool  { return starlark.True }
+func (p *Pattern) Hash() (uint32, error) { return hashString(p.pattern), nil }
+
+var patternMethods = map[string]builtinMethod{
+	"search": func(t *starlark.Thread, recv starlark.Value, a starlark.Tuple, k []starlark.Tuple) (starlark.Value, error) {
+		return recv.(*Pattern).methFind(a, k, "search")
+	},
+	"match": func(t *starlark.Thread, recv starlark.Value, a starlark.Tuple, k []starlark.Tuple) (starlark.Value, error) {
+		return recv.(*Pattern).methFind(a, k, "match")
+	},
+	"fullmatch": func(t *starlark.Thread, recv starlark.Value, a starlark.Tuple, k []starlark.Tuple) (starlark.Value, error) {
+		return recv.(*Pattern).methFind(a, k, "full")
+	},
+	"findall": func(t *starlark.Thread, recv starlark.Value, a starlark.Tuple, k []starlark.Tuple) (starlark.Value, error) {
+		return recv.(*Pattern).methFindall(a, k)
+	},
+	"finditer": func(t *starlark.Thread, recv starlark.Value, a starlark.Tuple, k []starlark.Tuple) (starlark.Value, error) {
+		return recv.(*Pattern).methFinditer(a, k)
+	},
+	"split": func(t *starlark.Thread, recv starlark.Value, a starlark.Tuple, k []starlark.Tuple) (starlark.Value, error) {
+		return recv.(*Pattern).methSplit(a, k)
+	},
+	"sub": func(t *starlark.Thread, recv starlark.Value, a starlark.Tuple, k []starlark.Tuple) (starlark.Value, error) {
+		return recv.(*Pattern).methSub(t, a, k, false)
+	},
+	"subn": func(t *starlark.Thread, recv starlark.Value, a starlark.Tuple, k []starlark.Tuple) (starlark.Value, error) {
+		return recv.(*Pattern).methSub(t, a, k, true)
+	},
+}
+
+func (p *Pattern) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "pattern":
+		return starlark.String(p.pattern), nil
+	case "flags":
+		return starlark.MakeInt(p.flags), nil
+	case "groups":
+		return starlark.MakeInt(p.search.NumSubexp()), nil
+	}
+	return builtinMethods(p, name, patternMethods)
+}
+
+func (p *Pattern) AttrNames() []string {
+	names := builtinAttrNames(patternMethods)
+	names = append(names, "pattern", "flags", "groups")
+	sort.Strings(names)
+	return names
+}
+
+func (p *Pattern) methFind(args starlark.Tuple, kwargs []starlark.Tuple, kind string) (starlark.Value, error) {
+	var str string
+	if err := starlark.UnpackArgs("("+kind+")", args, kwargs, "string", &str); err != nil {
+		return nil, err
+	}
+	return p.doFind(str, kind), nil
+}
+
+func (p *Pattern) methFindall(args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var str string
+	if err := starlark.UnpackArgs("findall", args, kwargs, "string", &str); err != nil {
+		return nil, err
+	}
+	return p.doFindall(str), nil
+}
+
+func (p *Pattern) methFinditer(args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var str string
+	if err := starlark.UnpackArgs("finditer", args, kwargs, "string", &str); err != nil {
+		return nil, err
+	}
+	return p.doFinditer(str), nil
+}
+
+func (p *Pattern) methSplit(args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		str      string
+		maxsplit int
+	)
+	if err := starlark.UnpackArgs("split", args, kwargs, "string", &str, "maxsplit?", &maxsplit); err != nil {
+		return nil, err
+	}
+	return p.doSplit(str, maxsplit), nil
+}
+
+func (p *Pattern) methSub(thread *starlark.Thread, args starlark.Tuple, kwargs []starlark.Tuple, withN bool) (starlark.Value, error) {
+	var (
+		repl  starlark.Value
+		str   string
+		count int
+	)
+	if err := starlark.UnpackArgs("sub", args, kwargs, "repl", &repl, "string", &str, "count?", &count); err != nil {
+		return nil, err
+	}
+	out, n, err := p.doSub(thread, repl, str, count)
+	if err != nil {
+		return nil, err
+	}
+	if withN {
+		return starlark.Tuple{starlark.String(out), starlark.MakeInt(n)}, nil
+	}
+	return starlark.String(out), nil
+}
+
+// ---- Match type ----
+
+// Match is the result of a successful search/match/fullmatch.
+type Match struct {
+	p   *Pattern
+	str string
+	loc []int // submatch index pairs, as from FindStringSubmatchIndex
+}
+
+func (m *Match) String() string        { return fmt.Sprintf("regex.Match(%q)", m.str[m.loc[0]:m.loc[1]]) }
+func (m *Match) Type() string          { return "regex.Match" }
+func (m *Match) Freeze()               {}
+func (m *Match) Truth() starlark.Bool  { return starlark.True }
+func (m *Match) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable type: regex.Match") }
+
+// groupIndex resolves a group selector (int index or name) to a numeric index.
+func (m *Match) groupIndex(v starlark.Value) (int, error) {
+	switch g := v.(type) {
+	case starlark.Int:
+		i, _ := g.Int64()
+		if i < 0 || int(i) > m.p.search.NumSubexp() {
+			return 0, fmt.Errorf("no such group: %d", i)
+		}
+		return int(i), nil
+	case starlark.String:
+		for i, name := range m.p.search.SubexpNames() {
+			if name == g.GoString() {
+				return i, nil
+			}
+		}
+		return 0, fmt.Errorf("no such group: %q", g.GoString())
+	default:
+		return 0, fmt.Errorf("group index must be an int or string, got %s", v.Type())
+	}
+}
+
+var matchMethods = map[string]builtinMethod{
+	"group": func(t *starlark.Thread, recv starlark.Value, a starlark.Tuple, k []starlark.Tuple) (starlark.Value, error) {
+		return recv.(*Match).methGroup(a, k)
+	},
+	"groups": func(t *starlark.Thread, recv starlark.Value, a starlark.Tuple, k []starlark.Tuple) (starlark.Value, error) {
+		return recv.(*Match).methGroups(a, k)
+	},
+	"groupdict": func(t *starlark.Thread, recv starlark.Value, a starlark.Tuple, k []starlark.Tuple) (starlark.Value, error) {
+		return recv.(*Match).methGroupdict(a, k)
+	},
+	"start": func(t *starlark.Thread, recv starlark.Value, a starlark.Tuple, k []starlark.Tuple) (starlark.Value, error) {
+		return recv.(*Match).methPos(a, k, true)
+	},
+	"end": func(t *starlark.Thread, recv starlark.Value, a starlark.Tuple, k []starlark.Tuple) (starlark.Value, error) {
+		return recv.(*Match).methPos(a, k, false)
+	},
+	"span": func(t *starlark.Thread, recv starlark.Value, a starlark.Tuple, k []starlark.Tuple) (starlark.Value, error) {
+		return recv.(*Match).methSpan(a, k)
+	},
+	"expand": func(t *starlark.Thread, recv starlark.Value, a starlark.Tuple, k []starlark.Tuple) (starlark.Value, error) {
+		return recv.(*Match).methExpand(a, k)
+	},
+}
+
+func (m *Match) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "string":
+		return starlark.String(m.str), nil
+	case "re":
+		return m.p, nil
+	}
+	return builtinMethods(m, name, matchMethods)
+}
+
+func (m *Match) AttrNames() []string {
+	names := builtinAttrNames(matchMethods)
+	names = append(names, "string", "re")
+	sort.Strings(names)
+	return names
+}
+
+// methGroup implements Match.group(*indices): no arg -> group(0); one arg ->
+// that group; several -> a tuple of them. Index may be int or name.
+func (m *Match) methGroup(args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if len(kwargs) > 0 {
+		return nil, fmt.Errorf("group: unexpected keyword argument")
+	}
+	if len(args) == 0 {
+		return groupText(m.str, m.loc, 0), nil
+	}
+	if len(args) == 1 {
+		gi, err := m.groupIndex(args[0])
+		if err != nil {
+			return nil, err
+		}
+		return groupText(m.str, m.loc, gi), nil
+	}
+	var out starlark.Tuple
+	for _, a := range args {
+		gi, err := m.groupIndex(a)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, groupText(m.str, m.loc, gi))
+	}
+	return out, nil
+}
+
+// methGroups returns a tuple of all capture groups, with a default for
+// non-participating groups (default is None unless given).
+func (m *Match) methGroups(args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var def starlark.Value = starlark.None
+	if err := starlark.UnpackArgs("groups", args, kwargs, "default?", &def); err != nil {
+		return nil, err
+	}
+	var out starlark.Tuple
+	for g := 1; g <= m.p.search.NumSubexp(); g++ {
+		v := groupText(m.str, m.loc, g)
+		if v == starlark.None {
+			v = def
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+// methGroupdict returns a dict of named groups to their text.
+func (m *Match) methGroupdict(args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var def starlark.Value = starlark.None
+	if err := starlark.UnpackArgs("groupdict", args, kwargs, "default?", &def); err != nil {
+		return nil, err
+	}
+	d := starlark.NewDict(0)
+	for i, name := range m.p.search.SubexpNames() {
+		if name == "" {
+			continue
+		}
+		v := groupText(m.str, m.loc, i)
+		if v == starlark.None {
+			v = def
+		}
+		if err := d.SetKey(starlark.String(name), v); err != nil {
+			return nil, err
+		}
+	}
+	return d, nil
+}
+
+func (m *Match) methPos(args starlark.Tuple, kwargs []starlark.Tuple, start bool) (starlark.Value, error) {
+	var gv starlark.Value = starlark.MakeInt(0)
+	if err := starlark.UnpackArgs("pos", args, kwargs, "group?", &gv); err != nil {
+		return nil, err
+	}
+	gi, err := m.groupIndex(gv)
+	if err != nil {
+		return nil, err
+	}
+	idx := m.loc[2*gi]
+	if !start {
+		idx = m.loc[2*gi+1]
+	}
+	return starlark.MakeInt(idx), nil
+}
+
+func (m *Match) methSpan(args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var gv starlark.Value = starlark.MakeInt(0)
+	if err := starlark.UnpackArgs("span", args, kwargs, "group?", &gv); err != nil {
+		return nil, err
+	}
+	gi, err := m.groupIndex(gv)
+	if err != nil {
+		return nil, err
+	}
+	return starlark.Tuple{starlark.MakeInt(m.loc[2*gi]), starlark.MakeInt(m.loc[2*gi+1])}, nil
+}
+
+func (m *Match) methExpand(args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var tmpl string
+	if err := starlark.UnpackArgs("expand", args, kwargs, "template", &tmpl); err != nil {
+		return nil, err
+	}
+	out := m.p.search.ExpandString(nil, translateRepl(tmpl), m.str, m.loc)
+	return starlark.String(out), nil
+}
+
+// ---- shared method-dispatch helpers ----
+
+type builtinMethod func(thread *starlark.Thread, recv starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error)
+
+func builtinMethods(recv starlark.Value, name string, methods map[string]builtinMethod) (starlark.Value, error) {
+	method := methods[name]
+	if method == nil {
+		return nil, nil // no such method
+	}
+	impl := func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		return method(thread, b.Receiver(), args, kwargs)
+	}
+	return starlark.NewBuiltin(name, impl).BindReceiver(recv), nil
+}
+
+func builtinAttrNames(methods map[string]builtinMethod) []string {
+	names := make([]string, 0, len(methods))
+	for name := range methods {
+		names = append(names, name)
+	}
+	return names
+}
+
+func hashString(s string) uint32 {
+	var h uint32 = 2166136261
+	for i := 0; i < len(s); i++ {
+		h ^= uint32(s[i])
+		h *= 16777619
+	}
+	return h
+}

--- a/lib/regex/regex_test.go
+++ b/lib/regex/regex_test.go
@@ -319,6 +319,180 @@ func TestLoadModule_Regex(t *testing.T) {
 			`),
 			wantErr: `no such group: "nope"`,
 		},
+		{
+			name:    `arg error: match`,
+			script:  "load('regex', 'match')\nmatch(1, 'a')",
+			wantErr: `for parameter pattern`,
+		},
+		{
+			name:    `arg error: fullmatch`,
+			script:  "load('regex', 'fullmatch')\nfullmatch()",
+			wantErr: `missing argument`,
+		},
+		{
+			name:    `arg error: findall`,
+			script:  "load('regex', 'findall')\nfindall('a')",
+			wantErr: `missing argument for string`,
+		},
+		{
+			name:    `arg error: finditer`,
+			script:  "load('regex', 'finditer')\nfinditer()",
+			wantErr: `missing argument`,
+		},
+		{
+			name:    `arg error: split`,
+			script:  "load('regex', 'split')\nsplit('a')",
+			wantErr: `missing argument for string`,
+		},
+		{
+			name:    `arg error: subn`,
+			script:  "load('regex', 'subn')\nsubn('a', 'b')",
+			wantErr: `missing argument for string`,
+		},
+		{
+			name:    `arg error: escape`,
+			script:  "load('regex', 'escape')\nescape()",
+			wantErr: `missing argument`,
+		},
+		{
+			name:    `arg error: compile bad type`,
+			script:  "load('regex', 'compile')\ncompile(123)",
+			wantErr: `for parameter pattern`,
+		},
+		{
+			name:    `arg error: pattern.search`,
+			script:  "load('regex', 'compile')\ncompile('a').search()",
+			wantErr: `missing argument`,
+		},
+		{
+			name:    `arg error: pattern.findall`,
+			script:  "load('regex', 'compile')\ncompile('a').findall()",
+			wantErr: `missing argument`,
+		},
+		{
+			name:    `arg error: pattern.finditer`,
+			script:  "load('regex', 'compile')\ncompile('a').finditer()",
+			wantErr: `missing argument`,
+		},
+		{
+			name:    `arg error: pattern.split`,
+			script:  "load('regex', 'compile')\ncompile('a').split()",
+			wantErr: `missing argument`,
+		},
+		{
+			name:    `arg error: pattern.sub`,
+			script:  "load('regex', 'compile')\ncompile('a').sub('x')",
+			wantErr: `missing argument for string`,
+		},
+		{
+			name:    `arg error: expand`,
+			script:  "load('regex', 'search')\nsearch('a', 'a').expand()",
+			wantErr: `missing argument`,
+		},
+		{
+			name:    `arg error: span bad type`,
+			script:  "load('regex', 'search')\nsearch('a', 'a').span([])",
+			wantErr: `group index must be an int or string`,
+		},
+		{
+			name: `pattern is hashable (dict key)`,
+			script: itn.HereDoc(`
+				load('regex', 'compile')
+				p = compile('a')
+				d = {p: 'v'}
+				assert.eq(d[p], 'v')
+			`),
+		},
+		{
+			name: `start/end/span by name; group default`,
+			script: itn.HereDoc(`
+				load('regex', 'search')
+				m = search(r'(?P<w>\w+)', 'hi')
+				assert.eq(m.start('w'), 0)
+				assert.eq(m.end('w'), 2)
+				assert.eq(m.span('w'), (0, 2))
+				m2 = search(r'(a)(b)?', 'a')
+				assert.eq(m2.groupdict(), {})
+				assert.eq(m2.group(), 'a')
+			`),
+		},
+		{
+			name: `repl: unclosed \g`,
+			script: itn.HereDoc(`
+				load('regex', 'sub')
+				assert.eq(sub('X', '\\g<unclosed', 'aXb'), 'a\\g<unclosedb')
+			`),
+		},
+		{
+			name:    `error: split invalid pattern`,
+			script:  "load('regex', 'split')\nsplit('(', 'a')",
+			wantErr: `cannot compile pattern`,
+		},
+		{
+			name:    `error: sub invalid pattern`,
+			script:  "load('regex', 'sub')\nsub('(', 'x', 'a')",
+			wantErr: `cannot compile pattern`,
+		},
+		{
+			name:    `error: subn invalid pattern`,
+			script:  "load('regex', 'subn')\nsubn('(', 'x', 'a')",
+			wantErr: `cannot compile pattern`,
+		},
+		{
+			name:    `error: finditer invalid pattern`,
+			script:  "load('regex', 'finditer')\nfinditer('(', 'a')",
+			wantErr: `cannot compile pattern`,
+		},
+		{
+			name:    `error: findall invalid pattern`,
+			script:  "load('regex', 'findall')\nfindall('(', 'a')",
+			wantErr: `cannot compile pattern`,
+		},
+		{
+			name:    `error: start by bad name`,
+			script:  "load('regex', 'search')\nsearch('(a)', 'a').start('nope')",
+			wantErr: `no such group: "nope"`,
+		},
+		{
+			name:    `error: span by bad name`,
+			script:  "load('regex', 'search')\nsearch('(a)', 'a').span('nope')",
+			wantErr: `no such group: "nope"`,
+		},
+		{
+			name:    `error: groups bad arg`,
+			script:  "load('regex', 'search')\nsearch('a', 'a').groups(1, 2, 3)",
+			wantErr: `groups: got 3 arguments`,
+		},
+		{
+			name:    `error: pattern has no such attr`,
+			script:  "load('regex', 'compile')\ncompile('a').nope",
+			wantErr: `no .nope field or method`,
+		},
+		{
+			name:    `error: match has no such attr`,
+			script:  "load('regex', 'search')\nsearch('a', 'a').nope",
+			wantErr: `no .nope field or method`,
+		},
+		{
+			name: `try_search: no match returns (None, None)`,
+			script: itn.HereDoc(`
+				load('regex', 'try_search')
+				res, err = try_search('z', 'abc')
+				assert.eq(res, None)
+				assert.eq(err, None)
+			`),
+		},
+		{
+			name: `sub via pattern with function repl`,
+			script: itn.HereDoc(`
+				load('regex', 'compile')
+				p = compile('[a-z]')
+				def up(m):
+					return m.group(0).upper()
+				assert.eq(p.sub(up, 'abc'), 'ABC')
+				assert.eq(p.subn('X', 'abc', 2), ('XXc', 2))
+			`),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/lib/regex/regex_test.go
+++ b/lib/regex/regex_test.go
@@ -1,0 +1,331 @@
+package regex_test
+
+import (
+	"testing"
+
+	itn "github.com/1set/starlet/internal"
+	"github.com/1set/starlet/lib/regex"
+)
+
+func TestLoadModule_Regex(t *testing.T) {
+	tests := []struct {
+		name    string
+		script  string
+		wantErr string
+	}{
+		{
+			name: `search: match and none`,
+			script: itn.HereDoc(`
+				load('regex', 'search')
+				m = search(r'(\w+)@(\w+)', 'reach ann@host now')
+				assert.eq(m.group(0), 'ann@host')
+				assert.eq(m.group(1), 'ann')
+				assert.eq(m.group(2), 'host')
+				assert.eq(m.span(0), (6, 14))
+				assert.eq(search('zzz', 'abc'), None)
+			`),
+		},
+		{
+			name: `match: anchored at start`,
+			script: itn.HereDoc(`
+				load('regex', 'match')
+				assert.eq(match('hello', 'hello world').group(0), 'hello')
+				assert.eq(match('world', 'hello world'), None)
+				assert.eq(match('(a)(b)', 'abc').group(1), 'a')
+			`),
+		},
+		{
+			name: `fullmatch: whole string, with backtracking`,
+			script: itn.HereDoc(`
+				load('regex', 'fullmatch')
+				assert.eq(fullmatch('a|ab', 'ab').group(0), 'ab')
+				assert.eq(fullmatch('a+', 'aaa').group(0), 'aaa')
+				assert.eq(fullmatch('a+', 'aaab'), None)
+			`),
+		},
+		{
+			name: `findall: python shaping by group count`,
+			script: itn.HereDoc(`
+				load('regex', 'findall')
+				assert.eq(findall(r'\d+', 'a1 b22 c333'), ('1', '22', '333'))
+				assert.eq(findall(r'(\w)(\d)', 'a1 b2'), (('a', '1'), ('b', '2')))
+				assert.eq(findall(r'x(\d)', 'x1 x2'), ('1', '2'))
+				assert.eq(findall('z', 'abc'), ())
+			`),
+		},
+		{
+			name: `finditer: list of matches`,
+			script: itn.HereDoc(`
+				load('regex', 'finditer')
+				ms = finditer(r'\d+', 'a1 b22')
+				assert.eq(len(ms), 2)
+				assert.eq([m.group(0) for m in ms], ['1', '22'])
+				assert.eq([m.span(0) for m in ms], [(1, 2), (4, 6)])
+			`),
+		},
+		{
+			name: `named groups: group by name, groupdict`,
+			script: itn.HereDoc(`
+				load('regex', 'search')
+				m = search(r'(?P<user>\w+)@(?P<host>\w+)', 'ann@example')
+				assert.eq(m.group('user'), 'ann')
+				assert.eq(m.group('host'), 'example')
+				assert.eq(m.groupdict(), {'user': 'ann', 'host': 'example'})
+				assert.eq(m.group('user', 'host'), ('ann', 'example'))
+			`),
+		},
+		{
+			name: `groups: optional group is None or default`,
+			script: itn.HereDoc(`
+				load('regex', 'search')
+				m = search(r'(a)(b)?', 'a')
+				assert.eq(m.groups(), ('a', None))
+				assert.eq(m.groups('X'), ('a', 'X'))
+			`),
+		},
+		{
+			name: `flags: ignorecase, multiline, dotall`,
+			script: itn.HereDoc(`
+				load('regex', 'search', 'findall', 'I', 'M', 'S')
+				assert.eq(search('hello', 'HELLO', I).group(0), 'HELLO')
+				assert.eq(findall('^x', 'x\nx\ny', M), ('x', 'x'))
+				assert.eq(search('a.b', 'a\nb', S).group(0), 'a\nb')
+				assert.eq(search('a.b', 'a\nb'), None)
+			`),
+		},
+		{
+			name: `sub: backreference translation and count`,
+			script: itn.HereDoc(`
+				load('regex', 'sub')
+				assert.eq(sub(r'(\w+)@(\w+)', r'\2.\1', 'ann@host'), 'host.ann')
+				assert.eq(sub(r'(?P<x>\d)', r'[\g<x>]', 'a1b2'), 'a[1]b[2]')
+				assert.eq(sub('a', 'X', 'aaa', 2), 'XXa')
+				assert.eq(sub('a', 'X', 'aaa', -1), 'aaa')
+				assert.eq(sub('a', '$', 'a'), '$')
+			`),
+		},
+		{
+			name: `sub: function replacement`,
+			script: itn.HereDoc(`
+				load('regex', 'sub')
+				def up(m):
+					return m.group(0).upper()
+				assert.eq(sub(r'[a-z]+', up, 'aa bb'), 'AA BB')
+			`),
+		},
+		{
+			name: `subn: returns count`,
+			script: itn.HereDoc(`
+				load('regex', 'subn')
+				assert.eq(subn('a', 'X', 'aaa'), ('XXX', 3))
+				assert.eq(subn('z', 'X', 'aaa'), ('aaa', 0))
+			`),
+		},
+		{
+			name: `split: includes capture groups, maxsplit`,
+			script: itn.HereDoc(`
+				load('regex', 'split')
+				assert.eq(split(r'\s+', 'a b  c'), ('a', 'b', 'c'))
+				assert.eq(split(r'(\s+)', 'a b'), ('a', ' ', 'b'))
+				assert.eq(split(',', 'a,b,c', 1), ('a', 'b,c'))
+			`),
+		},
+		{
+			name: `escape: quote meta`,
+			script: itn.HereDoc(`
+				load('regex', 'escape', 'search')
+				p = escape('a.b*c')
+				assert.eq(search(p, 'a.b*c').group(0), 'a.b*c')
+				assert.eq(search(p, 'axbyc'), None)
+			`),
+		},
+		{
+			name: `compile: pattern object and attrs`,
+			script: itn.HereDoc(`
+				load('regex', 'compile')
+				p = compile(r'(?P<n>\d+)')
+				assert.eq(p.pattern, r'(?P<n>\d+)')
+				assert.eq(p.groups, 1)
+				assert.eq(p.search('x42').group('n'), '42')
+				assert.eq(p.findall('1 2 3'), ('1', '2', '3'))
+				assert.eq(p.sub('#', 'a1b2'), 'a#b#')
+				assert.true(p.match('5x') != None)
+				assert.eq(p.match('x5'), None)
+			`),
+		},
+		{
+			name: `expand: template on a match`,
+			script: itn.HereDoc(`
+				load('regex', 'search')
+				m = search(r'(\w+) (\w+)', 'hello world')
+				assert.eq(m.expand(r'\2 \1'), 'world hello')
+			`),
+		},
+		{
+			name: `start end span`,
+			script: itn.HereDoc(`
+				load('regex', 'search')
+				m = search(r'b(c)', 'abcd')
+				assert.eq(m.start(0), 1)
+				assert.eq(m.end(0), 3)
+				assert.eq(m.start(1), 2)
+				assert.eq(m.span(1), (2, 3))
+			`),
+		},
+		{
+			name: `match attrs: string and re`,
+			script: itn.HereDoc(`
+				load('regex', 'search', 'compile')
+				m = search('b', 'abc')
+				assert.eq(m.string, 'abc')
+				assert.eq(m.re.pattern, 'b')
+			`),
+		},
+		// error cases
+		{
+			name: `error: invalid pattern`,
+			script: itn.HereDoc(`
+				load('regex', 'compile')
+				compile('(')
+			`),
+			wantErr: `cannot compile pattern`,
+		},
+		{
+			name: `error: lookbehind unsupported by RE2`,
+			script: itn.HereDoc(`
+				load('regex', 'compile')
+				compile(r'(?<=x)y')
+			`),
+			wantErr: `cannot compile pattern`,
+		},
+		{
+			name: `error: unsupported flags value`,
+			script: itn.HereDoc(`
+				load('regex', 'search')
+				search('a', 'a', 1024)
+			`),
+			wantErr: `unsupported flags value`,
+		},
+		{
+			name: `error: no such group`,
+			script: itn.HereDoc(`
+				load('regex', 'search')
+				search('(a)', 'a').group(5)
+			`),
+			wantErr: `no such group: 5`,
+		},
+		{
+			name: `error: bad repl type`,
+			script: itn.HereDoc(`
+				load('regex', 'sub')
+				sub('a', 123, 'a')
+			`),
+			wantErr: `repl must be a string or a function`,
+		},
+		{
+			name: `try_compile: ok and error`,
+			script: itn.HereDoc(`
+				load('regex', 'try_compile')
+				p, err = try_compile('a+')
+				assert.eq(err, None)
+				assert.true(p != None)
+				bad, err2 = try_compile('(')
+				assert.eq(bad, None)
+				assert.true('cannot compile' in err2)
+			`),
+		},
+		{
+			name: `try_search: error captured`,
+			script: itn.HereDoc(`
+				load('regex', 'try_search')
+				res, err = try_search('(', 'abc')
+				assert.eq(res, None)
+				assert.true('cannot compile' in err)
+			`),
+		},
+		{
+			name: `value protocol: str, type, bool, dir`,
+			script: itn.HereDoc(`
+				load('regex', 'compile', 'search')
+				p = compile('a')
+				assert.eq(type(p), 'regex.Pattern')
+				assert.true(bool(p))
+				assert.true('search' in dir(p))
+				assert.true('pattern' in dir(p))
+				assert.true('compile' in str(p))
+				m = search('b', 'abc')
+				assert.eq(type(m), 'regex.Match')
+				assert.true(bool(m))
+				assert.true('group' in dir(m))
+				assert.true('string' in dir(m))
+				assert.true('Match' in str(m))
+			`),
+		},
+		{
+			name: `match is unhashable`,
+			script: itn.HereDoc(`
+				load('regex', 'search')
+				m = search('a', 'a')
+				d = {}
+				d[m] = 1
+			`),
+			wantErr: `unhashable type: regex.Match`,
+		},
+		{
+			name: `sub: repl escape sequences`,
+			script: itn.HereDoc(`
+				load('regex', 'sub')
+				assert.eq(sub('X', '\\n', 'aXb'), 'a\nb')
+				assert.eq(sub('X', '\\t', 'aXb'), 'a\tb')
+				assert.eq(sub('X', '\\\\', 'aXb'), 'a\\b')
+				assert.eq(sub('X', 'lone\\q', 'X'), 'lone\\q')
+			`),
+		},
+		{
+			name: `findall via pattern object`,
+			script: itn.HereDoc(`
+				load('regex', 'compile')
+				p = compile(r'(\w)(\d)')
+				assert.eq(p.findall('a1 b2'), (('a', '1'), ('b', '2')))
+				assert.eq(p.finditer('a1')[0].group(2), '1')
+				assert.eq(p.split('a1xb2', 1)[0], '')
+				assert.eq(p.subn('#', 'a1b2'), ('##', 2))
+				assert.eq(p.fullmatch('a1').group(0), 'a1')
+			`),
+		},
+		{
+			name: `error: missing arguments`,
+			script: itn.HereDoc(`
+				load('regex', 'search')
+				search()
+			`),
+			wantErr: `missing argument`,
+		},
+		{
+			name: `error: sub function returns non-string`,
+			script: itn.HereDoc(`
+				load('regex', 'sub')
+				def bad(m):
+					return 42
+				sub('a', bad, 'a')
+			`),
+			wantErr: `repl function must return a string`,
+		},
+		{
+			name: `error: group by bad name`,
+			script: itn.HereDoc(`
+				load('regex', 'search')
+				search('(a)', 'a').group('nope')
+			`),
+			wantErr: `no such group: "nope"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := itn.ExecModuleWithErrorTest(t, regex.ModuleName, regex.LoadModule, tt.script, tt.wantErr, nil)
+			if (err != nil) != (tt.wantErr != "") {
+				t.Errorf("regex(%q) expects error = '%v', actual error = '%v', result = %v", tt.name, tt.wantErr, err, res)
+			}
+		})
+	}
+}

--- a/module_test.go
+++ b/module_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	builtinModules = []string{"atom", "base64", "csv", "file", "go_idiomatic", "hashlib", "http", "json", "log", "math", "net", "path", "random", "re", "runtime", "stats", "string", "struct", "time"}
+	builtinModules = []string{"atom", "base64", "csv", "file", "go_idiomatic", "hashlib", "http", "json", "log", "math", "net", "path", "random", "re", "regex", "runtime", "stats", "string", "struct", "time"}
 )
 
 func TestListBuiltinModules(t *testing.T) {


### PR DESCRIPTION
## Why

Adds **`lib/regex`**, the successor to the frozen legacy `re` module (Backlog **ADR-011**, route B). The old `re` was a structural dead end — no Match object, `findall` dropped capture groups, named groups `(?P<name>)` had no extraction path — and starlet #132 already froze it after making its silent-wrong behaviors honest. The semantic completion lives in a new module.

## What

A **Python `re` subset on Go's RE2 engine** — linear-time matching, ReDoS-immune, fit for running untrusted/LLM-generated scripts in a sandbox. Shapes that align with Python are matched faithfully; the genuine RE2 differences (lookaround `(?=...)`/`(?<=...)`, in-pattern backreferences `\1`) **fail to compile with a clear error** instead of silently misbehaving. **Zero new dependencies** — RE2 is the stdlib `regexp` the repo already links.

- **Functions**: `compile` / `search` / `match` / `fullmatch` / `findall` / `finditer` / `sub` / `subn` / `split` / `escape` + `try_compile` / `try_search`.
- **Flags**: `I`/`IGNORECASE`, `M`/`MULTILINE`, `S`/`DOTALL` (Python values, OR-able → RE2 inline flags).
- **Pattern** type (compiled) with the method forms + `pattern`/`flags`/`groups` attrs.
- **Match** object: `group(n|name)` / `groups(default)` / `groupdict(default)` / `start` / `end` / `span` / `expand`; `None` for non-participating groups; unhashable.
- **Semantics matched to Python**: `findall` group shaping (0→full / 1→group / 2+→tuple), `match`/`fullmatch` anchoring (`\A` / `\A...\z`, with backtracking — e.g. `fullmatch('a|ab','ab')` matches `ab`), `split` includes capture-group text, `sub` with `\1`/`\g<name>` templates or a **function replacement**, negative `count` replaces nothing.

## Peripheral ring (a new module is never just the package)

Wired in everywhere a module must be: `config.go` registration **+ capability classification** (`CapPure` — `TestModuleCapabilities` fails the build otherwise), `module_test.go` builtin list (`TestListBuiltinModules` asserts the exact set), the repo README libraries table and `Modules:` example, and the module's own README.

## Verification

Test-first golden tests (86.8% coverage), `go test -race -count=2 ./lib/regex/`, full local race suite, and the full suite under `golang:1.19` Docker — all green. Legacy `re` is untouched.

Refs: ADR-011

🤖 Generated with [Claude Code](https://claude.com/claude-code)