### PR TITLE
[feat] json: repair/try_repair for tolerant JSON recovery (LLM output)

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,9 @@
+---
+# Codacy configuration for starlet.
+#
+# Exclude the vendored, pinned third-party JSON-repair runtime from static
+# analysis. lib/json/internal/jsonrepair is a verbatim copy of
+# kaptinlin/jsonrepair v0.2.2 (MIT); its style/complexity is upstream's to
+# own, and the copy is kept byte-for-byte so it can be re-vendored cleanly.
+exclude_paths:
+  - 'lib/json/internal/jsonrepair/**'

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+# Codecov configuration for starlet.
+#
+# Exclude the vendored, pinned third-party JSON-repair runtime from coverage.
+# lib/json/internal/jsonrepair is a verbatim copy of kaptinlin/jsonrepair
+# v0.2.2 (MIT), frozen at its go1.18/1.19-compatible release. It is exercised
+# through the json.repair tests, but mirroring its upstream branch coverage is
+# not a gate this repository maintains.
+ignore:
+  - "lib/json/internal/jsonrepair"
+  - "lib/json/internal/jsonrepair/**/*"

--- a/lib/json/README.md
+++ b/lib/json/README.md
@@ -282,3 +282,50 @@ print("Error:", error)
 # Result: 9.323333333333334
 # Error: None
 ```
+
+### `repair(text) string`
+
+The repair function recovers valid JSON **text** from the messy output that language models often produce, so the result can then be passed to `decode`. It accepts one required positional parameter, the text, and returns a JSON string.
+
+It fixes the common breakages: code fences (` ```json … ``` `), surrounding prose, single-quoted keys/strings, trailing commas, comments, Python literals (`True`/`False`/`None`), unquoted keys, and truncated (cut-off) JSON.
+
+It returns **text, not a value** — the idiom is `decode(repair(x))`, which keeps repair composable with `decode`'s `default` and the `try_*` variants. Because repair returns text, a recovered bare scalar (e.g. the input `The answer is 42` yields `42`) is honest output; scripts that require a structured result should check the type of the decoded value.
+
+**Already-valid JSON is returned byte-for-byte unchanged** (repair is idempotent on good input), so it is safe to call defensively.
+
+#### Examples
+
+**Basic**
+
+Repair a fenced, single-quoted, trailing-comma response and decode it.
+
+```python
+load('json', 'repair', 'decode')
+messy = '''Here is the result:
+```json
+{'name': 'Ann', 'tags': ['a', 'b',],}
+```
+'''
+print(decode(repair(messy)))
+# Output: {'name': 'Ann', 'tags': ['a', 'b']}
+```
+
+### `try_repair(text) tuple`
+
+The try_repair function is a variant of repair that handles errors gracefully.
+It accepts the same parameter as repair, but returns a tuple of (result, error).
+If successful, error will be None. If an error occurs, result will be None and error will contain the error message.
+
+#### Examples
+
+**Basic**
+
+```python
+load('json', 'try_repair')
+result, error = try_repair('{"a": 1,}')
+print("Result:", result)
+print("Error:", error)
+# Output:
+# Result: {"a": 1}
+# Error: None
+```

--- a/lib/json/internal/jsonrepair/LICENSE
+++ b/lib/json/internal/jsonrepair/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 KaptinLin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/json/internal/jsonrepair/const.go
+++ b/lib/json/internal/jsonrepair/const.go
@@ -1,0 +1,70 @@
+package jsonrepair
+
+// Define character codes
+const (
+	codeBackslash               = 0x5c // "\"
+	codeSlash                   = 0x2f // "/"
+	codeAsterisk                = 0x2a // "*"
+	codeOpeningBrace            = 0x7b // "{"
+	codeClosingBrace            = 0x7d // "}"
+	codeOpeningBracket          = 0x5b // "["
+	codeClosingBracket          = 0x5d // "]"
+	codeOpenParenthesis         = 0x28 // "("
+	codeCloseParenthesis        = 0x29 // ")"
+	codeSpace                   = 0x20 // " "
+	codeNewline                 = 0xa  // "\n"
+	codeTab                     = 0x9  // "\t"
+	codeReturn                  = 0xd  // "\r"
+	codeBackspace               = 0x08 // "\b"
+	codeFormFeed                = 0x0c // "\f"
+	codeDoubleQuote             = 0x22 // "
+	codePlus                    = 0x2b // "+"
+	codeMinus                   = 0x2d // "-"
+	codeQuote                   = 0x27 // "'"
+	codeZero                    = 0x30 // "0"
+	codeNine                    = 0x39 // "9"
+	codeComma                   = 0x2c // ","
+	codeDot                     = 0x2e // "." (dot, period)
+	codeColon                   = 0x3a // ":"
+	codeSemicolon               = 0x3b // ";"
+	codeUppercaseA              = 0x41 // "A"
+	codeLowercaseA              = 0x61 // "a"
+	codeUppercaseE              = 0x45 // "E"
+	codeLowercaseE              = 0x65 // "e"
+	codeUppercaseF              = 0x46 // "F"
+	codeLowercaseF              = 0x66 // "f"
+	codeNonBreakingSpace        = 0xa0
+	codeEnQuad                  = 0x2000
+	codeHairSpace               = 0x200a
+	codeNarrowNoBreakSpace      = 0x202f
+	codeMediumMathematicalSpace = 0x205f
+	codeIdeographicSpace        = 0x3000
+	codeDoubleQuoteLeft         = 0x201c // “
+	codeDoubleQuoteRight        = 0x201d // ”
+	codeQuoteLeft               = 0x2018 // ‘
+	codeQuoteRight              = 0x2019 // ’
+	codeGraveAccent             = 0x60   // `
+	codeAcuteAccent             = 0xb4   // ´
+)
+
+// Define control and escape character mappings according to JSON standard (RFC 8259)
+var controlCharacters = map[rune]string{
+	codeBackspace: `\b`,
+	codeFormFeed:  `\f`,
+	codeNewline:   `\n`,
+	codeReturn:    `\r`,
+	codeTab:       `\t`,
+}
+
+// JSON standard escape characters - these MUST be escaped or CAN be escaped in JSON strings
+var escapeCharacters = map[rune]string{
+	'"':  "\"", // MUST be escaped
+	'\\': "\\", // MUST be escaped
+	'/':  "/",  // CAN be escaped (optional)
+	'b':  "\b", // Backspace control character
+	'f':  "\f", // Form feed control character
+	'n':  "\n", // Newline control character
+	'r':  "\r", // Carriage return control character
+	't':  "\t", // Tab control character
+	// Note: 'u' is handled separately for Unicode escape sequences (\uXXXX)
+}

--- a/lib/json/internal/jsonrepair/doc.go
+++ b/lib/json/internal/jsonrepair/doc.go
@@ -1,0 +1,12 @@
+// Package jsonrepair is a vendored copy of github.com/kaptinlin/jsonrepair at
+// v0.2.2 (MIT License — see the LICENSE file in this directory, Copyright (c)
+// 2024 KaptinLin).
+//
+// It is vendored rather than taken as a module dependency so that starlet
+// keeps zero third-party dependencies and stays pinned to a release whose Go
+// floor is 1.18/1.19; later jsonrepair releases raise the floor to go1.24.
+// Only the runtime files are copied (const.go, errors.go, jsonrepair.go,
+// utils.go) — the upstream test suite and its testify/yaml.v3 test
+// dependencies are intentionally excluded. Do not edit these files by hand;
+// re-vendor from the upstream tag to update.
+package jsonrepair

--- a/lib/json/internal/jsonrepair/errors.go
+++ b/lib/json/internal/jsonrepair/errors.go
@@ -1,0 +1,76 @@
+package jsonrepair
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Predefined error variables for use with errors.Is()
+var (
+	ErrUnexpectedEnd       = errors.New("unexpected end of json string")
+	ErrObjectKeyExpected   = errors.New("object key expected")
+	ErrColonExpected       = errors.New("colon expected")
+	ErrInvalidCharacter    = errors.New("invalid character")
+	ErrUnexpectedCharacter = errors.New("unexpected character")
+	ErrInvalidUnicode      = errors.New("invalid unicode character")
+)
+
+// JSONRepairError represents a structured JSON repair error.
+// It provides the error message, position, and optional underlying error
+type JSONRepairError struct {
+	Message  string
+	Position int
+	Err      error // optional underlying error
+}
+
+// Error implements the error interface
+func (e *JSONRepairError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("%s at position %d: %v", e.Message, e.Position, e.Err)
+	}
+	return fmt.Sprintf("%s at position %d", e.Message, e.Position)
+}
+
+// Unwrap allows JSONRepairError to support errors.Is / errors.As
+func (e *JSONRepairError) Unwrap() error {
+	return e.Err
+}
+
+// newJSONRepairError creates a new JSONRepairError with optional error wrapping
+// Usage:
+//
+//	newJSONRepairError("Unexpected character", 42)
+//	newJSONRepairError("Invalid unicode character", 13, ErrInvalidUnicode)
+//	newJSONRepairError("Unexpected character", 42, ErrUnexpectedCharacter)
+func newJSONRepairError(message string, position int, err ...error) *JSONRepairError {
+	var inner error
+	if len(err) > 0 {
+		inner = err[0]
+	}
+	return &JSONRepairError{Message: message, Position: position, Err: inner}
+}
+
+// Convenience functions for creating specific error types with predefined errors wrapped
+func newUnexpectedEndError(position int) *JSONRepairError {
+	return newJSONRepairError("Unexpected end of json string", position, ErrUnexpectedEnd)
+}
+
+func newObjectKeyExpectedError(position int) *JSONRepairError {
+	return newJSONRepairError("Object key expected", position, ErrObjectKeyExpected)
+}
+
+func newColonExpectedError(position int) *JSONRepairError {
+	return newJSONRepairError("Colon expected", position, ErrColonExpected)
+}
+
+func newUnexpectedCharacterError(message string, position int) *JSONRepairError {
+	return newJSONRepairError(message, position, ErrUnexpectedCharacter)
+}
+
+func newInvalidUnicodeError(message string, position int) *JSONRepairError {
+	return newJSONRepairError(message, position, ErrInvalidUnicode)
+}
+
+func newInvalidCharacterError(message string, position int) *JSONRepairError {
+	return newJSONRepairError(message, position, ErrInvalidCharacter)
+}

--- a/lib/json/internal/jsonrepair/jsonrepair.go
+++ b/lib/json/internal/jsonrepair/jsonrepair.go
@@ -1,0 +1,1112 @@
+package jsonrepair
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// JSONRepair attempts to repair the given JSON string and returns the repaired version.
+func JSONRepair(text string) (string, error) {
+	// Check for empty input - matches TypeScript version behavior
+	if len(text) == 0 {
+		return "", newUnexpectedEndError(0)
+	}
+
+	runes := []rune(text)
+	i := 0
+	var output strings.Builder
+
+	// Parse leading Markdown code block
+	parseMarkdownCodeBlock(&runes, &i, []string{"```", "[```", "{```"}, &output)
+
+	success, err := parseValue(&runes, &i, &output)
+	if err != nil {
+		return "", err
+	}
+	if !success {
+		return "", newUnexpectedEndError(len(runes))
+	}
+
+	// Parse trailing Markdown code block
+	parseMarkdownCodeBlock(&runes, &i, []string{"```", "```]", "```}"}, &output)
+
+	processedComma := parseCharacter(&runes, &i, &output, codeComma)
+	if processedComma {
+		parseWhitespaceAndSkipComments(&runes, &i, &output, true)
+	}
+
+	if i < len(runes) && isStartOfValue(runes[i]) && endsWithCommaOrNewline(output.String()) {
+		if !processedComma {
+			outputStr := insertBeforeLastWhitespace(output.String(), ",")
+			output.Reset()
+			output.WriteString(outputStr)
+		}
+		parseNewlineDelimitedJSON(&runes, &i, &output)
+	} else if processedComma {
+		outputStr := stripLastOccurrence(output.String(), ",", false)
+		output.Reset()
+		output.WriteString(outputStr)
+	}
+
+	// repair redundant end quotes
+	for i < len(runes) && (runes[i] == codeClosingBrace || runes[i] == codeClosingBracket) {
+		i++
+		parseWhitespaceAndSkipComments(&runes, &i, &output, true)
+	}
+
+	// Skip any remaining whitespace before checking for unexpected characters
+	parseWhitespaceAndSkipComments(&runes, &i, &output, true)
+
+	if i >= len(runes) {
+		return output.String(), nil
+	}
+
+	// Check for specific unrepairable cases based on TypeScript version behavior
+	// These are cases where we have remaining characters that can't be processed
+	if i < len(runes) {
+		char := runes[i]
+
+		// Check if this looks like the problematic cases from TypeScript tests:
+		// 1. "callback {}" - invalid JSONP without parentheses
+		// 2. "{"a":2}foo" - extra content after valid JSON
+		// 3. "foo [" - invalid content
+
+		// Special case for current Go test format (temporary, to be unified later)
+		if string(char) == "{" && i == 9 {
+			// This matches the existing Go test expectation for "callback {}"
+			message := fmt.Sprintf("unexpected character: '%c' at position %d", char, i)
+			return "", newUnexpectedCharacterError(message, i)
+		}
+
+		// Default format for other cases
+		message := fmt.Sprintf("Unexpected character %q", string(char))
+		return "", newUnexpectedCharacterError(message, i)
+	}
+
+	return output.String(), nil
+}
+
+// parseValue determines the type of the next value in the input text and parses it accordingly.
+// Returns (success, error) where error is non-nil only for non-repairable issues
+func parseValue(text *[]rune, i *int, output *strings.Builder) (bool, error) {
+	parseWhitespaceAndSkipComments(text, i, output, true)
+
+	// Try parseObject first and handle potential errors
+	if processedObj, err := parseObject(text, i, output); err != nil {
+		return false, err
+	} else if processedObj {
+		parseWhitespaceAndSkipComments(text, i, output, true)
+		return true, nil
+	}
+
+	// Try other parsers with original logic
+	processed := parseArray(text, i, output)
+	if !processed {
+		// Try parseString and handle errors (matches TypeScript version)
+		stringProcessed, err := parseString(text, i, output, false, -1)
+		if err != nil {
+			return false, err
+		}
+		processed = stringProcessed ||
+			parseNumber(text, i, output) ||
+			parseKeywords(text, i, output) ||
+			parseUnquotedString(text, i, output) ||
+			parseRegex(text, i, output)
+	}
+	parseWhitespaceAndSkipComments(text, i, output, true)
+
+	// Post-parsing validation removed - errors should be detected during parsing
+
+	return processed, nil
+}
+
+// parseWhitespaceAndSkipComments parses whitespace and skips comments.
+func parseWhitespaceAndSkipComments(text *[]rune, i *int, output *strings.Builder, skipNewline bool) bool {
+	start := *i
+	parseWhitespace(text, i, output, skipNewline)
+	for {
+		changed := parseComment(text, i)
+		if changed {
+			changed = parseWhitespace(text, i, output, skipNewline)
+		}
+
+		if !changed {
+			break
+		}
+	}
+
+	return *i > start
+}
+
+// parseWhitespace parses whitespace characters.
+func parseWhitespace(text *[]rune, i *int, output *strings.Builder, skipNewline bool) bool {
+	start := *i
+	whitespace := strings.Builder{}
+
+	isW := isWhitespace
+	if !skipNewline {
+		isW = isWhitespaceExceptNewline
+	}
+
+	for *i < len(*text) && (isW((*text)[*i]) || isSpecialWhitespace((*text)[*i])) {
+		if !isSpecialWhitespace((*text)[*i]) {
+			whitespace.WriteRune((*text)[*i])
+		} else {
+			whitespace.WriteRune(' ') // repair special whitespace
+		}
+		*i++
+	}
+
+	if whitespace.Len() > 0 {
+		output.WriteString(whitespace.String())
+		return true
+	}
+	return *i > start
+}
+
+// parseComment parses both single-line (//) and multi-line (/* */) comments.
+func parseComment(text *[]rune, i *int) bool {
+	if *i+1 < len(*text) {
+		if (*text)[*i] == codeSlash && (*text)[*i+1] == codeAsterisk { // multi-line comment
+			// repair block comment by skipping it
+			for *i < len(*text) && !atEndOfBlockComment(text, i) {
+				*i++
+			}
+			if *i+2 <= len(*text) {
+				*i += 2 // move past the end of the block comment
+			}
+			return true
+		} else if (*text)[*i] == codeSlash && (*text)[*i+1] == codeSlash { // single-line comment
+			// repair line comment by skipping it
+			for *i < len(*text) && (*text)[*i] != codeNewline {
+				*i++
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// parseCharacter parses a specific character and adds it to the output if it matches the expected code.
+func parseCharacter(text *[]rune, i *int, output *strings.Builder, code rune) bool {
+	if *i < len(*text) && (*text)[*i] == code {
+		output.WriteRune((*text)[*i])
+		*i++
+		return true
+	}
+	return false
+}
+
+// skipCharacter skips a specific character in the input text if it matches the expected code.
+func skipCharacter(text *[]rune, i *int, code rune) bool {
+	if *i < len(*text) && (*text)[*i] == code {
+		*i++
+		return true
+	}
+	return false
+}
+
+// skipEscapeCharacter skips an escape character in the input text.
+func skipEscapeCharacter(text *[]rune, i *int) bool {
+	return skipCharacter(text, i, codeBackslash)
+}
+
+// skipEllipsis skips ellipsis (three dots) in arrays or objects.
+func skipEllipsis(text *[]rune, i *int, output *strings.Builder) bool {
+	parseWhitespaceAndSkipComments(text, i, output, true)
+
+	if *i+2 < len(*text) &&
+		(*text)[*i] == codeDot &&
+		(*text)[*i+1] == codeDot &&
+		(*text)[*i+2] == codeDot {
+		*i += 3
+		parseWhitespaceAndSkipComments(text, i, output, true)
+		skipCharacter(text, i, codeComma)
+		return true
+	}
+	return false
+}
+
+// parseObject parses an object from the input text.
+// Returns (success, error) where error is non-nil for non-repairable issues
+func parseObject(text *[]rune, i *int, output *strings.Builder) (bool, error) {
+	if *i < len(*text) && (*text)[*i] == codeOpeningBrace {
+		output.WriteRune((*text)[*i])
+		*i++
+		parseWhitespaceAndSkipComments(text, i, output, true)
+
+		// repair: skip leading comma like in {, message: "hi"}
+		if skipCharacter(text, i, codeComma) {
+			parseWhitespaceAndSkipComments(text, i, output, true)
+		}
+
+		initial := true
+		for *i < len(*text) && (*text)[*i] != codeClosingBrace {
+			if !initial {
+				iBefore := *i
+				oBefore := output.Len()
+				// parse optional comma
+				processedComma := parseCharacter(text, i, output, codeComma)
+				if processedComma {
+					// We just appended the comma, but it may be located *after* a
+					// previously written whitespace sequence (for example a
+					// newline and indentation). In order to keep the output
+					// consistent with the reference implementation, we move the
+					// comma so that it comes *before* those trailing
+					// whitespaces.
+					temp := output.String()
+					// Remove the comma we just wrote (it is guaranteed to be
+					// the last rune).
+					if strings.HasSuffix(temp, ",") {
+						temp = temp[:len(temp)-1]
+						// Re-insert the comma before the trailing whitespace
+						temp = insertBeforeLastWhitespace(temp, ",")
+
+						// After moving the comma, remove the spaces that are
+						// still attached to the newline – they will be
+						// re-added when we later write the original
+						// whitespace found in the source text. This prevents
+						// duplicating the indentation (which previously
+						// resulted in 4 spaces instead of 2).
+						if idx := strings.LastIndex(temp, "\n"); idx != -1 {
+							// Only trim spaces when they are *trailing* after the newline.
+							j := idx + 1
+							for j < len(temp) && (temp[j] == ' ' || temp[j] == '\t') {
+								j++
+							}
+							if j == len(temp) {
+								// All remaining characters are whitespace → safe to trim.
+								temp = temp[:idx+1]
+							}
+						}
+						output.Reset()
+						output.WriteString(temp)
+					}
+				} else {
+					// repair missing comma (original logic)
+					*i = iBefore
+					tempStr := output.String()
+					output.Reset()
+					output.WriteString(tempStr[:oBefore])
+
+					outputStr := insertBeforeLastWhitespace(output.String(), ",")
+					output.Reset()
+					output.WriteString(outputStr)
+				}
+			} else {
+				initial = false
+			}
+
+			skipEllipsis(text, i, output)
+
+			// Try parseString for object key and handle errors
+			stringProcessed, err := parseString(text, i, output, false, -1)
+			if err != nil {
+				return false, err
+			}
+			processedKey := stringProcessed || parseUnquotedStringWithMode(text, i, output, true)
+			if !processedKey {
+				if *i >= len(*text) ||
+					(*text)[*i] == codeClosingBrace ||
+					(*text)[*i] == codeOpeningBrace ||
+					(*text)[*i] == codeClosingBracket ||
+					(*text)[*i] == codeOpeningBracket ||
+					(*text)[*i] == 0 {
+					// repair trailing comma
+					outputStr := stripLastOccurrence(output.String(), ",", false)
+					output.Reset()
+					output.WriteString(outputStr)
+				} else {
+					// TypeScript version throws "Object key expected" error here
+					return false, newObjectKeyExpectedError(*i)
+				}
+				break
+			}
+
+			parseWhitespaceAndSkipComments(text, i, output, true)
+			processedColon := parseCharacter(text, i, output, codeColon)
+			truncatedText := *i >= len(*text)
+			if !processedColon {
+				if *i < len(*text) && isStartOfValue((*text)[*i]) || truncatedText {
+					// repair missing colon
+					outputStr := insertBeforeLastWhitespace(output.String(), ":")
+					output.Reset()
+					output.WriteString(outputStr)
+				} else {
+					// TypeScript version throws "Colon expected" error here
+					return false, newColonExpectedError(*i)
+				}
+			}
+			processedValue, err := parseValue(text, i, output)
+			if err != nil {
+				// Forward error from parseValue
+				return false, err
+			}
+			if !processedValue {
+				if processedColon || truncatedText {
+					// repair missing object value
+					output.WriteString("null")
+				} else {
+					// throwColonExpected() equivalent
+					return false, nil
+				}
+			}
+		}
+
+		if *i < len(*text) && (*text)[*i] == codeClosingBrace {
+			output.WriteRune((*text)[*i])
+			*i++
+		} else {
+			// repair missing end bracket
+			outputStr := insertBeforeLastWhitespace(output.String(), "}")
+			output.Reset()
+			output.WriteString(outputStr)
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+// parseArray parses an array from the input text.
+func parseArray(text *[]rune, i *int, output *strings.Builder) bool {
+	if *i >= len(*text) {
+		return false
+	}
+
+	if (*text)[*i] == codeOpeningBracket {
+		output.WriteRune((*text)[*i])
+		*i++
+		parseWhitespaceAndSkipComments(text, i, output, true)
+
+		if skipCharacter(text, i, codeComma) {
+			parseWhitespaceAndSkipComments(text, i, output, true)
+		}
+
+		initial := true
+		for *i < len(*text) && (*text)[*i] != codeClosingBracket {
+			if !initial {
+				iBefore := *i
+				oBefore := output.Len()
+				parseWhitespaceAndSkipComments(text, i, output, true)
+
+				processedComma := parseCharacter(text, i, output, codeComma)
+				if !processedComma {
+					*i = iBefore
+					tempStr := output.String()
+					output.Reset()
+					output.WriteString(tempStr[:oBefore])
+
+					// repair missing comma
+					outputStr := insertBeforeLastWhitespace(output.String(), ",")
+					output.Reset()
+					output.WriteString(outputStr)
+				}
+			} else {
+				initial = false
+			}
+
+			skipEllipsis(text, i, output)
+
+			processedValue, err := parseValue(text, i, output)
+			if err != nil {
+				// Forward error from parseValue
+				return false
+			}
+
+			// Clean up a trailing comma that is **inside** a JSON string when
+			// it is directly followed by the string's closing quote. This
+			// situation typically comes from an input like "hello,world,"2
+			// where the comma actually belongs between two array items but
+			// ended up inside the first string. We must *not* touch a string
+			// that is literally just a comma (",") – that is a valid value
+			// in a JSON array.
+			if processedValue {
+				outputStr := output.String()
+
+				// We look for ...",\"  (comma just before the closing quote).
+				if strings.HasSuffix(outputStr, ",\"") {
+					// Ensure the string contains more than just that comma.
+					// The minimal string we do NOT want to alter is ",",
+					// which would look like ["\",\"]. That has length 3
+					// including the comma and quotes -> 4 characters in the
+					// output (opening [, closing ], quotes). A safer check is
+					// to verify that inside the quotes we have more than one
+					// character.
+
+					// Find the position of the opening quote for this value.
+					lastQuote := strings.LastIndex(outputStr[:len(outputStr)-2], "\"")
+					if lastQuote != -1 && len(outputStr)-2-lastQuote > 2 {
+						cleanedStr := outputStr[:len(outputStr)-2] + "\""
+						output.Reset()
+						output.WriteString(cleanedStr)
+					}
+				}
+			}
+
+			// Note: the TypeScript reference implementation does not attempt to
+			// strip trailing commas that are *inside* JSON strings here. Any
+			// such cleanup is handled during string parsing itself. Keeping the
+			// Go implementation aligned with the reference prevents accidental
+			// removal of valid characters such as a standalone "," string.
+
+			if !processedValue {
+				// repair trailing comma
+				outputStr := stripLastOccurrence(output.String(), ",", false)
+				output.Reset()
+				output.WriteString(outputStr)
+				break
+			}
+		}
+
+		if *i < len(*text) && (*text)[*i] == codeClosingBracket {
+			output.WriteRune((*text)[*i])
+			*i++
+		} else {
+			// repair missing closing array bracket
+			outputStr := insertBeforeLastWhitespace(output.String(), "]")
+			output.Reset()
+			output.WriteString(outputStr)
+		}
+		return true
+	}
+	return false
+}
+
+// parseNewlineDelimitedJSON parses Newline Delimited JSON (NDJSON) from the input text.
+func parseNewlineDelimitedJSON(text *[]rune, i *int, output *strings.Builder) {
+	initial := true
+	processedValue := true
+
+	for processedValue {
+		if !initial {
+			// parse optional comma, insert when missing
+			processedComma := parseCharacter(text, i, output, codeComma)
+			if !processedComma {
+				// repair: add missing comma
+				outputStr := insertBeforeLastWhitespace(output.String(), ",")
+				output.Reset()
+				output.WriteString(outputStr)
+			}
+		} else {
+			initial = false
+		}
+
+		var err error
+		processedValue, err = parseValue(text, i, output)
+		if err != nil {
+			// For now, treat errors as parse failure in NDJSON context
+			processedValue = false
+		}
+	}
+
+	if !processedValue {
+		// repair: remove trailing comma
+		outputStr := stripLastOccurrence(output.String(), ",", false)
+		output.Reset()
+		output.WriteString(outputStr)
+	}
+
+	// repair: wrap the output inside array brackets
+	outputStr := fmt.Sprintf("[\n%s\n]", output.String())
+	output.Reset()
+	output.WriteString(outputStr)
+}
+
+// parseString parses a string from the input text, handling various quote and escape scenarios.
+// Returns (success, error) - error is non-nil for non-repairable issues (matches TypeScript version)
+func parseString(text *[]rune, i *int, output *strings.Builder, stopAtDelimiter bool, stopAtIndex int) (bool, error) {
+	if *i >= len(*text) {
+		return false, nil
+	}
+
+	skipEscapeChars := (*text)[*i] == codeBackslash
+	if skipEscapeChars {
+		// repair: remove the first escape character
+		*i++
+	}
+
+	if *i < len(*text) && isQuote((*text)[*i]) {
+		isEndQuote := func(r rune) bool { return r == (*text)[*i] }
+		if isDoubleQuote((*text)[*i]) {
+			isEndQuote = isDoubleQuote
+		} else if isSingleQuote((*text)[*i]) {
+			isEndQuote = isSingleQuote
+		} else if isSingleQuoteLike((*text)[*i]) {
+			isEndQuote = isSingleQuoteLike
+		} else if isDoubleQuoteLike((*text)[*i]) {
+			isEndQuote = isDoubleQuoteLike
+		}
+
+		iBefore := *i
+		oBefore := output.Len()
+
+		// Analyze if this string might contain file paths
+		mightContainFilePaths := analyzePotentialFilePath(text, *i)
+
+		var str strings.Builder
+		str.WriteRune('"')
+		*i++
+
+		for {
+			if *i >= len(*text) {
+				// end of text, we are missing an end quote
+				iPrev := prevNonWhitespaceIndex(*text, *i-1)
+				if !stopAtDelimiter && iPrev != -1 && isDelimiter((*text)[iPrev]) {
+					// if the text ends with a delimiter, like ["hello],
+					// so the missing end quote should be inserted before this delimiter
+					// retry parsing the string, stopping at the first next delimiter
+					*i = iBefore
+					tempStr := output.String()
+					output.Reset()
+					output.WriteString(tempStr[:oBefore])
+					return parseString(text, i, output, true, -1)
+				}
+
+				// repair missing quote
+				strStr := insertBeforeLastWhitespace(str.String(), "\"")
+				output.WriteString(strStr)
+				return true, nil
+			}
+
+			if stopAtIndex != -1 && *i == stopAtIndex {
+				// use the stop index detected in the first iteration, and repair end quote
+				strStr := insertBeforeLastWhitespace(str.String(), "\"")
+				output.WriteString(strStr)
+				return true, nil
+			}
+
+			if isEndQuote((*text)[*i]) {
+				// end quote
+				iQuote := *i
+				oQuote := str.Len()
+				str.WriteRune('"')
+				*i++
+				output.WriteString(str.String())
+
+				iAfterWhitespace := *i
+				var tempWhitespace strings.Builder
+				parseWhitespaceAndSkipComments(text, &iAfterWhitespace, &tempWhitespace, false)
+
+				if stopAtDelimiter || iAfterWhitespace >= len(*text) || isDelimiter((*text)[iAfterWhitespace]) || isQuote((*text)[iAfterWhitespace]) || isDigit((*text)[iAfterWhitespace]) {
+					// The quote is followed by the end of the text, a delimiter,
+					// or a next value. So the quote is indeed the end of the string.
+					*i = iAfterWhitespace
+					output.WriteString(tempWhitespace.String())
+					parseConcatenatedString(text, i, output)
+					return true, nil
+				}
+
+				iPrevChar := prevNonWhitespaceIndex(*text, iQuote-1)
+				if iPrevChar != -1 {
+					prevChar := (*text)[iPrevChar]
+					if prevChar == ',' {
+						*i = iBefore
+						tempStr := output.String()
+						output.Reset()
+						output.WriteString(tempStr[:oBefore])
+						return parseString(text, i, output, false, iPrevChar)
+					}
+
+					if isDelimiter(prevChar) {
+						*i = iBefore
+						tempStr := output.String()
+						output.Reset()
+						output.WriteString(tempStr[:oBefore])
+						return parseString(text, i, output, true, -1)
+					}
+				}
+
+				// revert to right after the quote but before any whitespace, and continue parsing the string
+				tempStr := output.String()
+				output.Reset()
+				output.WriteString(tempStr[:oBefore])
+				*i = iQuote + 1
+
+				// repair unescaped quote
+				revertedStr := str.String()[:oQuote] + "\\\""
+				str.Reset()
+				str.WriteString(revertedStr)
+			} else if stopAtDelimiter && isUnquotedStringDelimiter((*text)[*i]) {
+				// we're in the mode to stop the string at the first delimiter
+				// because there is an end quote missing
+				if *i > 0 && (*text)[*i-1] == ':' && regexUrlStart.MatchString(string((*text)[iBefore+1:*i+2])) {
+					for *i < len(*text) && regexUrlChar.MatchString(string((*text)[*i])) {
+						str.WriteRune((*text)[*i])
+						*i++
+					}
+				}
+
+				// repair missing quote
+				strStr := insertBeforeLastWhitespace(str.String(), "\"")
+				output.WriteString(strStr)
+				parseConcatenatedString(text, i, output)
+				return true, nil
+			} else if (*text)[*i] == '\\' {
+				// handle escaped content like \n or \u2605
+				if *i+1 >= len(*text) {
+					// repair: incomplete escape sequence at end of string
+					// just remove the backslash and end the string
+					strStr := insertBeforeLastWhitespace(str.String(), "\"")
+					output.WriteString(strStr)
+					*i++
+					return true, nil
+				}
+
+				char := (*text)[*i+1]
+				if _, ok := escapeCharacters[char]; ok {
+					if mightContainFilePaths {
+						// In file path context, escape the backslash as literal
+						str.WriteString("\\\\")
+						*i += 1
+					} else {
+						// Valid JSON escape character - keep as is
+						str.WriteRune((*text)[*i])
+						str.WriteRune((*text)[*i+1])
+						*i += 2
+					}
+				} else if char == 'u' {
+					// Handle Unicode escape sequences
+					j := 2
+					hexCount := 0
+					// Count valid hex characters
+					for j < 6 && *i+j < len(*text) && isHex((*text)[*i+j]) {
+						j++
+						hexCount++
+					}
+
+					if hexCount == 4 {
+						if mightContainFilePaths {
+							// In file path context, escape the backslash as literal
+							str.WriteString("\\\\")
+							*i += 1
+						} else {
+							// Valid Unicode escape sequence - keep as is
+							str.WriteString(string((*text)[*i : *i+6]))
+							*i += 6
+						}
+					} else if *i+j >= len(*text) {
+						// repair invalid or truncated unicode char at the end of the text
+						// by removing the unicode char and ending the string here
+						*i = len(*text)
+					} else {
+						// Invalid Unicode escape sequence
+						if mightContainFilePaths && hexCount == 0 && *i+2 < len(*text) {
+							// In file path context, \u followed by non-hex might be literal backslash
+							// For example: \users, \util, etc.
+							nextChar := (*text)[*i+2]
+							if (nextChar >= 'a' && nextChar <= 'z') || (nextChar >= 'A' && nextChar <= 'Z') {
+								// Looks like \users, \util - treat as literal backslash
+								str.WriteString("\\\\")
+								*i += 1
+							} else {
+								// Still looks like malformed Unicode escape - throw error
+								endJ := 2 // Start after \u
+								for endJ < 6 && *i+endJ < len(*text) {
+									nextChar := (*text)[*i+endJ]
+									if nextChar == '"' || nextChar == '\'' || isWhitespace(nextChar) {
+										break
+									}
+									endJ++
+								}
+								chars := string((*text)[*i : *i+endJ])
+								escapedChars := strings.ReplaceAll(chars, "\\", "\\\\")
+								return false, newInvalidUnicodeError(fmt.Sprintf("Invalid unicode character \"%s\"", escapedChars), *i)
+							}
+						} else {
+							// Not in file path context or malformed Unicode - throw error
+							endJ := 2 // Start after \u
+							for endJ < 6 && *i+endJ < len(*text) {
+								nextChar := (*text)[*i+endJ]
+								// Stop at whitespace or string delimiters
+								if nextChar == '"' || nextChar == '\'' || isWhitespace(nextChar) {
+									break
+								}
+								endJ++
+							}
+
+							chars := string((*text)[*i : *i+endJ])
+							// Format to match TypeScript
+							escapedChars := strings.ReplaceAll(chars, "\\", "\\\\")
+
+							// Add extra quote only for incomplete sequences like "\u26"
+							if hexCount < 4 && endJ == 2+hexCount {
+								// Incomplete sequence like "\u26" needs extra quote
+								return false, newInvalidUnicodeError(fmt.Sprintf("Invalid unicode character \"%s\"\"", escapedChars), *i)
+							} else {
+								// Complete but invalid sequence like "\uZ000"
+								return false, newInvalidUnicodeError(fmt.Sprintf("Invalid unicode character \"%s\"", escapedChars), *i)
+							}
+						}
+					}
+				} else {
+					if mightContainFilePaths {
+						// In file path context, escape the backslash as literal
+						str.WriteString("\\\\")
+						*i += 1
+					} else {
+						// Default behavior: remove invalid escape character
+						str.WriteRune(char)
+						*i += 2
+					}
+				}
+			} else {
+				// handle regular characters
+				char := (*text)[*i]
+				if char == '"' && (*text)[*i-1] != '\\' {
+					// repair unescaped double quote
+					str.WriteString("\\\"")
+					*i++
+				} else if isControlCharacter(char) {
+					// unescaped control character
+					if replacement, ok := controlCharacters[char]; ok {
+						str.WriteString(replacement)
+					}
+					*i++
+				} else {
+					// Check character validity - matches TypeScript throwInvalidCharacter()
+					if !isValidStringCharacter(char) {
+						// Format control characters as Unicode escape sequences to match TypeScript
+						message := fmt.Sprintf("Invalid character \"\\\\u%04x\"", char)
+						return false, newInvalidCharacterError(message, *i)
+					}
+					str.WriteRune(char)
+					*i++
+				}
+			}
+
+			if skipEscapeChars {
+				// repair: skipped escape character (nothing to do)
+				skipEscapeCharacter(text, i)
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// parseConcatenatedString parses and repairs concatenated strings (e.g., "hello" + "world").
+func parseConcatenatedString(text *[]rune, i *int, output *strings.Builder) bool {
+	processed := false
+
+	iBeforeWhitespace := *i
+	oBeforeWhitespace := output.Len()
+	parseWhitespaceAndSkipComments(text, i, output, true)
+
+	for *i < len(*text) && (*text)[*i] == '+' {
+		processed = true
+		*i++
+		parseWhitespaceAndSkipComments(text, i, output, true)
+
+		// repair: remove the end quote of the first string
+		outputStr := stripLastOccurrence(output.String(), "\"", true)
+		output.Reset()
+		output.WriteString(outputStr)
+		start := output.Len()
+
+		// Try parseString and handle errors
+		stringProcessed, err := parseString(text, i, output, false, -1)
+		if err != nil {
+			// For concatenated strings, errors are not critical - just stop processing
+			stringProcessed = false
+		}
+		if stringProcessed {
+			// repair: remove the start quote of the second string
+			outputStr = output.String()
+			if len(outputStr) > start {
+				output.Reset()
+				output.WriteString(removeAtIndex(outputStr, start, 1))
+			}
+		} else {
+			// repair: remove the + because it is not followed by a string
+			outputStr = insertBeforeLastWhitespace(output.String(), "\"")
+			output.Reset()
+			output.WriteString(outputStr)
+		}
+	}
+
+	if !processed {
+		// revert parsing whitespace
+		*i = iBeforeWhitespace
+		tempStr := output.String()
+		output.Reset()
+		output.WriteString(tempStr[:oBeforeWhitespace])
+	}
+
+	return processed
+}
+
+// parseNumber parses a number from the input text, handling various numeric formats.
+func parseNumber(text *[]rune, i *int, output *strings.Builder) bool {
+	start := *i
+	if *i < len(*text) && (*text)[*i] == codeMinus {
+		*i++
+		if atEndOfNumber(text, i) {
+			repairNumberEndingWithNumericSymbol(text, start, i, output)
+			return true
+		}
+		if !isDigit((*text)[*i]) {
+			*i = start
+			return false
+		}
+	}
+
+	// Note that in JSON leading zeros like "00789" are not allowed.
+	// We will allow all leading zeros here though and at the end of parseNumber
+	// check against trailing zeros and repair that if needed.
+	// Leading zeros can have meaning, so we should not clear them.
+	for *i < len(*text) && isDigit((*text)[*i]) {
+		*i++
+	}
+
+	if *i < len(*text) && (*text)[*i] == codeDot {
+		*i++
+		if atEndOfNumber(text, i) {
+			repairNumberEndingWithNumericSymbol(text, start, i, output)
+			return true
+		}
+		if !isDigit((*text)[*i]) {
+			*i = start
+			return false
+		}
+		for *i < len(*text) && isDigit((*text)[*i]) {
+			*i++
+		}
+	}
+
+	if *i < len(*text) && ((*text)[*i] == codeLowercaseE || (*text)[*i] == codeUppercaseE) {
+		*i++
+		if *i < len(*text) && ((*text)[*i] == codeMinus || (*text)[*i] == codePlus) {
+			*i++
+		}
+		if atEndOfNumber(text, i) {
+			repairNumberEndingWithNumericSymbol(text, start, i, output)
+			return true
+		}
+		if !isDigit((*text)[*i]) {
+			*i = start
+			return false
+		}
+		for *i < len(*text) && isDigit((*text)[*i]) {
+			*i++
+		}
+	}
+
+	if !atEndOfNumber(text, i) {
+		*i = start
+		return false
+	}
+
+	if *i > start {
+		num := string((*text)[start:*i])
+		hasInvalidLeadingZero := regexp.MustCompile(`^0\d`).MatchString(num)
+		if hasInvalidLeadingZero {
+			fmt.Fprintf(output, `"%s"`, num)
+		} else {
+			output.WriteString(num)
+		}
+		return true
+	}
+	return false
+}
+
+// parseKeywords parses and repairs JSON keywords (true, false, null) and Python keywords (True, False, None).
+func parseKeywords(text *[]rune, i *int, output *strings.Builder) bool {
+	return parseKeyword(text, i, output, "true", "true") ||
+		parseKeyword(text, i, output, "false", "false") ||
+		parseKeyword(text, i, output, "null", "null") ||
+		parseKeyword(text, i, output, "True", "true") ||
+		parseKeyword(text, i, output, "False", "false") ||
+		parseKeyword(text, i, output, "None", "null")
+}
+
+// parseKeyword parses a specific keyword from the input text.
+func parseKeyword(text *[]rune, i *int, output *strings.Builder, name, value string) bool {
+	if len(*text)-*i >= len(name) && string((*text)[*i:*i+len(name)]) == name {
+		output.WriteString(value)
+		*i += len(name)
+		return true
+	}
+	return false
+}
+
+// parseUnquotedString parses and repairs unquoted strings, MongoDB function calls, and JSONP function calls.
+func parseUnquotedString(text *[]rune, i *int, output *strings.Builder) bool {
+	return parseUnquotedStringWithMode(text, i, output, false)
+}
+
+// parseUnquotedStringWithMode parses unquoted strings with a mode parameter to control URL parsing
+func parseUnquotedStringWithMode(text *[]rune, i *int, output *strings.Builder, isKey bool) bool {
+	start := *i
+
+	if *i >= len(*text) {
+		return false
+	}
+
+	// Check for function name start (MongoDB/JSONP function calls)
+	if isFunctionNameCharStart((*text)[*i]) {
+		for *i < len(*text) && isFunctionNameChar((*text)[*i]) {
+			*i++
+		}
+
+		j := *i
+		for j < len(*text) && isWhitespace((*text)[j]) {
+			j++
+		}
+
+		if j < len(*text) && (*text)[j] == codeOpenParenthesis {
+			// repair a MongoDB function call like NumberLong("2")
+			// repair a JSONP function call like callback({...});
+			*i = j + 1
+
+			// Parse the value inside parentheses, ignore errors for JSONP/MongoDB calls
+			_, _ = parseValue(text, i, output)
+
+			if *i < len(*text) && (*text)[*i] == codeCloseParenthesis {
+				// repair: skip close bracket of function call
+				*i++
+				if *i < len(*text) && (*text)[*i] == codeSemicolon {
+					// repair: skip semicolon after JSONP call
+					*i++
+				}
+			}
+
+			return true
+		}
+	}
+
+	// Check if this starts with a URL pattern (only when not parsing a key)
+	isURL := false
+	if !isKey {
+		if start+8 <= len(*text) && string((*text)[start:start+8]) == "https://" {
+			isURL = true
+		} else if start+7 <= len(*text) && string((*text)[start:start+7]) == "http://" {
+			isURL = true
+		} else if start+6 <= len(*text) && string((*text)[start:start+6]) == "ftp://" {
+			isURL = true
+		}
+	}
+
+	if isURL {
+		// Parse as URL - continue until we hit a proper delimiter (not slash)
+		for *i < len(*text) && isUrlChar((*text)[*i]) {
+			*i++
+		}
+	} else {
+		// Move the index forward until a delimiter or quote is found
+		for *i < len(*text) && !isUnquotedStringDelimiter((*text)[*i]) && !isQuote((*text)[*i]) {
+			// If we're parsing a key and encounter a colon, stop here
+			if isKey && (*text)[*i] == codeColon {
+				break
+			}
+			*i++
+		}
+	}
+
+	if *i > start {
+		// repair unquoted string
+		// also, repair undefined into null
+
+		// first, go back to prevent getting trailing whitespaces in the string
+		for *i > start && isWhitespace((*text)[*i-1]) {
+			*i--
+		}
+
+		symbol := string((*text)[start:*i])
+
+		if symbol == "undefined" {
+			output.WriteString("null")
+		} else {
+			// Ensure special quotes are replaced with double quotes
+			repairedSymbol := strings.Builder{}
+			for _, char := range symbol {
+				if isSingleQuoteLike(char) || isDoubleQuoteLike(char) {
+					repairedSymbol.WriteRune('"')
+				} else {
+					repairedSymbol.WriteRune(char)
+				}
+			}
+			fmt.Fprintf(output, `"%s"`, repairedSymbol.String())
+		}
+
+		// Skip the end quote if encountered
+		if *i < len(*text) && (*text)[*i] == codeDoubleQuote {
+			*i++
+		}
+
+		return true
+	}
+	return false
+}
+
+// parseRegex parses a regular expression literal like /pattern/flags.
+func parseRegex(text *[]rune, i *int, output *strings.Builder) bool {
+	if *i < len(*text) && (*text)[*i] == codeSlash {
+		start := *i
+		*i++
+
+		for *i < len(*text) && ((*text)[*i] != codeSlash || (*text)[*i-1] == codeBackslash) {
+			*i++
+		}
+
+		if *i < len(*text) && (*text)[*i] == codeSlash {
+			*i++
+		}
+
+		// Process the regex content to handle escape characters properly
+		regexContent := string((*text)[start:*i])
+		// Ensure backslashes are properly escaped in the output JSON string
+		regexContent = strings.ReplaceAll(regexContent, "\\", "\\\\")
+
+		fmt.Fprintf(output, `"%s"`, regexContent)
+		return true
+	}
+	return false
+}
+
+// parseMarkdownCodeBlock parses and skips Markdown fenced code blocks like ``` or ```json
+func parseMarkdownCodeBlock(text *[]rune, i *int, blocks []string, output *strings.Builder) bool {
+	if skipMarkdownCodeBlock(text, i, blocks) {
+		if *i < len(*text) && isFunctionNameCharStart((*text)[*i]) {
+			// Strip the optional language specifier like "json"
+			for *i < len(*text) && isFunctionNameChar((*text)[*i]) {
+				*i++
+			}
+		}
+
+		// Add any whitespace after code block marker to output
+		for *i < len(*text) && (isWhitespace((*text)[*i]) || isSpecialWhitespace((*text)[*i])) {
+			if isWhitespace((*text)[*i]) {
+				output.WriteRune((*text)[*i])
+			} else {
+				output.WriteRune(' ') // repair special whitespace
+			}
+			*i++
+		}
+
+		return true
+	}
+	return false
+}
+
+// skipMarkdownCodeBlock checks if we're at a Markdown code block marker and skips it
+func skipMarkdownCodeBlock(text *[]rune, i *int, blocks []string) bool {
+	for _, block := range blocks {
+		blockRunes := []rune(block)
+		end := *i + len(blockRunes)
+		if end <= len(*text) {
+			match := true
+			for j := 0; j < len(blockRunes); j++ {
+				if (*text)[*i+j] != blockRunes[j] {
+					match = false
+					break
+				}
+			}
+			if match {
+				*i = end
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/lib/json/internal/jsonrepair/utils.go
+++ b/lib/json/internal/jsonrepair/utils.go
@@ -1,0 +1,729 @@
+package jsonrepair
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// prevNonWhitespaceIndex finds the previous non-whitespace index in the string.
+func prevNonWhitespaceIndex(text []rune, startIndex int) int {
+	prev := startIndex
+	for prev >= 0 && isWhitespace(text[prev]) {
+		prev--
+	}
+	return prev
+}
+
+// atEndOfBlockComment checks if the current position is at the end of a block comment.
+func atEndOfBlockComment(text *[]rune, i *int) bool {
+	return *i+1 < len(*text) && (*text)[*i] == codeAsterisk && (*text)[*i+1] == codeSlash
+}
+
+// atEndOfNumber checks if the end of a number has been reached in the input text.
+func atEndOfNumber(text *[]rune, i *int) bool {
+	return *i >= len(*text) || isDelimiter((*text)[*i]) || isWhitespace((*text)[*i])
+}
+
+// repairNumberEndingWithNumericSymbol repairs numbers cut off at the end.
+func repairNumberEndingWithNumericSymbol(text *[]rune, start int, i *int, output *strings.Builder) {
+	output.WriteString(string((*text)[start:*i]) + "0")
+}
+
+// stripLastOccurrence removes the last occurrence of a specific substring from the input text.
+func stripLastOccurrence(text, textToStrip string, stripRemainingText bool) string {
+	index := strings.LastIndex(text, textToStrip)
+	if index != -1 {
+		if stripRemainingText {
+			return text[:index]
+		}
+		return text[:index] + text[index+len(textToStrip):]
+	}
+	return text
+}
+
+// insertBeforeLastWhitespace inserts a substring before the last whitespace in the input text.
+// For comma insertion, we want to insert after the value but before any trailing whitespace.
+func insertBeforeLastWhitespace(s, textToInsert string) string {
+	// If the last character is not whitespace, simply append the text to insert.
+	if len(s) == 0 || !isWhitespace(rune(s[len(s)-1])) {
+		return s + textToInsert
+	}
+
+	// Walk backwards over all trailing whitespace characters (space, tab, cr, lf).
+	index := len(s) - 1
+	for index >= 0 {
+		if !isWhitespace(rune(s[index])) {
+			break
+		}
+		index--
+	}
+
+	// index now points at the last non-whitespace character.
+	return s[:index+1] + textToInsert + s[index+1:]
+}
+
+// removeAtIndex removes a substring from the input text at a specific index.
+func removeAtIndex(text string, start, count int) string {
+	return text[:start] + text[start+count:]
+}
+
+// isHex checks if a rune is a hexadecimal digit.
+func isHex(code rune) bool {
+	return (code >= codeZero && code <= codeNine) ||
+		(code >= codeUppercaseA && code <= codeUppercaseF) ||
+		(code >= codeLowercaseA && code <= codeLowercaseF)
+}
+
+// isDigit checks if a rune is a digit.
+func isDigit(code rune) bool {
+	return code >= codeZero && code <= codeNine
+}
+
+// isValidStringCharacter checks if a character is valid inside a JSON string
+// Matches TypeScript version: char >= '\u0020'
+func isValidStringCharacter(char rune) bool {
+	return char >= 0x0020
+}
+
+// isDelimiter checks if a character is a delimiter.
+func isDelimiter(char rune) bool {
+	return regexDelimiter.MatchString(string(char))
+}
+
+// regexDelimiter matches a single JSON delimiter character used to separate tokens.
+// The character class explicitly lists all delimiter characters and escapes special
+// characters to prevent unintended character ranges (e.g. ":[" would otherwise
+// create a range from ':' to '[').
+var regexDelimiter = regexp.MustCompile(`^[,:\[\]/{}()\n\+]$`)
+
+// isStartOfValue checks if a rune is the start of a JSON value.
+func isStartOfValue(char rune) bool {
+	return regexStartOfValue.MatchString(string(char)) || isQuote(char)
+}
+
+// regexStartOfValue defines the regular expression for the start of a JSON value.
+var regexStartOfValue = regexp.MustCompile(`^[{[\w-]$`)
+
+// isControlCharacter checks if a rune is a control character.
+func isControlCharacter(code rune) bool {
+	return code == codeNewline ||
+		code == codeReturn ||
+		code == codeTab ||
+		code == codeBackspace ||
+		code == codeFormFeed
+}
+
+// isWhitespace checks if a rune is a whitespace character.
+func isWhitespace(code rune) bool {
+	return code == codeSpace ||
+		code == codeNewline ||
+		code == codeTab ||
+		code == codeReturn
+}
+
+// isSpecialWhitespace checks if a rune is a special whitespace character.
+func isSpecialWhitespace(code rune) bool {
+	return code == codeNonBreakingSpace ||
+		(code >= codeEnQuad && code <= codeHairSpace) ||
+		code == codeNarrowNoBreakSpace ||
+		code == codeMediumMathematicalSpace ||
+		code == codeIdeographicSpace
+}
+
+// isQuote checks if a rune is a quote character.
+func isQuote(code rune) bool {
+	return isDoubleQuoteLike(code) || isSingleQuoteLike(code)
+}
+
+// isDoubleQuoteLike checks if a rune is a double quote or a variant of double quote.
+func isDoubleQuoteLike(code rune) bool {
+	return code == codeDoubleQuote ||
+		code == codeDoubleQuoteLeft ||
+		code == codeDoubleQuoteRight
+}
+
+// isDoubleQuote checks if a rune is a double quote.
+func isDoubleQuote(code rune) bool {
+	return code == codeDoubleQuote
+}
+
+// isSingleQuoteLike checks if a rune is a single quote or a variant of single quote.
+func isSingleQuoteLike(code rune) bool {
+	return code == codeQuote ||
+		code == codeQuoteLeft ||
+		code == codeQuoteRight ||
+		code == codeGraveAccent ||
+		code == codeAcuteAccent
+}
+
+// isSingleQuote checks if a rune is a single quote.
+func isSingleQuote(code rune) bool {
+	return code == codeQuote
+}
+
+// endsWithCommaOrNewline checks if the string ends with a comma or newline character and optional whitespace.
+// This function should only match commas that are outside of quoted strings.
+func endsWithCommaOrNewline(text string) bool {
+	if len(text) == 0 {
+		return false
+	}
+
+	// Find the last non-whitespace character
+	runes := []rune(text)
+	i := len(runes) - 1
+
+	// Skip trailing whitespace
+	for i >= 0 && (runes[i] == ' ' || runes[i] == '\t' || runes[i] == '\r') {
+		i--
+	}
+
+	if i < 0 {
+		return false
+	}
+
+	// Check if the last non-whitespace character is a comma or newline
+	// But only if it's not inside a quoted string
+	if runes[i] == ',' || runes[i] == '\n' {
+		// Simple check: if the text ends with a quoted string, the comma is likely inside the string
+		// A more robust approach would be to parse the JSON structure, but for now we use a heuristic
+		trimmed := strings.TrimSpace(text)
+		if len(trimmed) > 0 && trimmed[len(trimmed)-1] == '"' {
+			// The text ends with a quote, so any comma before it is likely a JSON separator
+			// Look for the pattern: "..." , or "...",
+			return regexp.MustCompile(`"[ \t\r]*[,\n][ \t\r]*$`).MatchString(text)
+		}
+		return true
+	}
+
+	return false
+}
+
+// isFunctionNameCharStart checks if a rune is a valid function name start character.
+func isFunctionNameCharStart(code rune) bool {
+	return (code >= 'a' && code <= 'z') || (code >= 'A' && code <= 'Z') || code == '_' || code == '$'
+}
+
+// isFunctionNameChar checks if a rune is a valid function name character.
+func isFunctionNameChar(code rune) bool {
+	return isFunctionNameCharStart(code) || isDigit(code)
+}
+
+// isUnquotedStringDelimiter checks if a character is a delimiter for unquoted strings.
+func isUnquotedStringDelimiter(char rune) bool {
+	return regexUnquotedStringDelimiter.MatchString(string(char))
+}
+
+// Similar to regexDelimiter but without ':' since a colon is allowed inside an
+// unquoted value until we detect a key/value separator.
+var regexUnquotedStringDelimiter = regexp.MustCompile(`^[,\[\]/{}\n\+]$`)
+
+// isWhitespaceExceptNewline checks if a rune is a whitespace character except newline.
+func isWhitespaceExceptNewline(code rune) bool {
+	return code == codeSpace || code == codeTab || code == codeReturn
+}
+
+// URL-related regular expressions and functions
+var regexUrlStart = regexp.MustCompile(`^(https?|ftp|mailto|file|data|irc)://`)
+var regexUrlChar = regexp.MustCompile(`^[A-Za-z0-9\-._~:/?#@!$&'()*+;=]$`)
+
+// isUrlChar checks if a rune is a valid URL character.
+func isUrlChar(code rune) bool {
+	return regexUrlChar.MatchString(string(code))
+}
+
+// Regular expression cache for improved performance
+var (
+	driveLetterRe   = regexp.MustCompile(`^[A-Za-z]:\\`)
+	containsDriveRe = regexp.MustCompile(`[A-Za-z]:\\`)
+	base64Re        = regexp.MustCompile(`^[A-Za-z0-9+/=]{20,}$`)
+	fileExtensionRe = regexp.MustCompile(`(?i)\.[a-z0-9]{2,5}(\?|$|\\|"|/)`)
+	unicodeEscapeRe = regexp.MustCompile(`\\u[0-9a-fA-F]{4}`)
+	urlEncodingRe   = regexp.MustCompile(`%[0-9a-fA-F]{2}`)
+)
+
+// ================================
+// EARLY EXCLUSION FILTERS
+// ================================
+
+// hasExcessiveEscapeSequences checks if content has too many escape sequences to be a valid file path
+func hasExcessiveEscapeSequences(content string) bool {
+	if len(content) < 3 {
+		return false
+	}
+
+	// Count Unicode escape sequences
+	unicodeMatches := unicodeEscapeRe.FindAllString(content, -1)
+	if len(unicodeMatches) >= 2 {
+		totalUnicodeLength := len(unicodeMatches) * 6 // Each \uXXXX is 6 chars
+		if float64(totalUnicodeLength)/float64(len(content)) > 0.6 {
+			return true
+		}
+	}
+
+	// Count general escape sequences
+	escapeCount := 0
+	for i := 0; i < len(content)-1; i++ {
+		if content[i] == '\\' {
+			next := content[i+1]
+			if next == 'n' || next == 't' || next == 'r' || next == 'b' || next == 'f' || next == '"' || next == '\\' {
+				escapeCount++
+			}
+		}
+	}
+
+	// If more than 30% of content is escape sequences, likely not a path
+	if escapeCount > 0 && float64(escapeCount*2)/float64(len(content)) > 0.3 {
+		return true
+	}
+
+	return false
+}
+
+// isLikelyTextBlob identifies content that has text-like characteristics
+func isLikelyTextBlob(content string) bool {
+	if len(content) < 3 {
+		return false
+	}
+
+	// Multiple consecutive spaces (rare in paths)
+	if strings.Contains(content, "  ") {
+		return true
+	}
+
+	// Contains line breaks or tabs
+	if strings.Contains(content, "\n") || strings.Contains(content, "\t") || strings.Contains(content, "\r") {
+		return true
+	}
+
+	// Sentence-like punctuation patterns
+	if strings.Contains(content, ". ") || strings.Contains(content, "! ") || strings.Contains(content, "? ") {
+		return true
+	}
+
+	// Too many spaces for a typical path (more than 5 spaces instead of 3)
+	spaceCount := strings.Count(content, " ")
+	if spaceCount > 5 {
+		return true
+	}
+
+	// Sentence-like capitalization pattern (more restrictive)
+	if len(content) > 10 && content[0] >= 'A' && content[0] <= 'Z' && spaceCount > 2 {
+		lowercaseAfterSpace := 0
+		foundSpace := false
+		for _, r := range content[1:] {
+			if r == ' ' {
+				foundSpace = true
+			} else if foundSpace && r >= 'a' && r <= 'z' {
+				lowercaseAfterSpace++
+			}
+		}
+		if lowercaseAfterSpace >= 3 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isBase64String checks if content appears to be base64 encoded
+func isBase64String(content string) bool {
+	if len(content) < 20 {
+		return false
+	}
+	return base64Re.MatchString(content)
+}
+
+// hasURLEncoding checks if content contains URL encoding patterns
+func hasURLEncoding(content string) bool {
+	return urlEncodingRe.MatchString(content)
+}
+
+// ================================
+// PATH FORMAT DETECTION
+// ================================
+
+// isWindowsAbsolutePath checks for Windows absolute paths (drive letter format)
+func isWindowsAbsolutePath(content string) bool {
+	return driveLetterRe.MatchString(content) || containsDriveRe.MatchString(content)
+}
+
+// isUNCPath checks for UNC (Universal Naming Convention) paths
+func isUNCPath(content string) bool {
+	if !strings.HasPrefix(content, `\\`) || strings.HasPrefix(content, `\\\\`) {
+		return false
+	}
+
+	parts := strings.Split(content, `\`)
+	// UNC: \\server\share\path... (parts[0]="", parts[1]="", parts[2]=server, parts[3]=share)
+	return len(parts) >= 4 && len(parts[2]) > 0 && len(parts[3]) > 0
+}
+
+// isUnixAbsolutePath checks for Unix absolute paths
+func isUnixAbsolutePath(content string) bool {
+	return strings.HasPrefix(content, "/") || strings.HasPrefix(content, "~/")
+}
+
+// isURLPath checks for URL-style file paths
+func isURLPath(content string) bool {
+	lowerContent := strings.ToLower(content)
+
+	// Exclude HTTP/HTTPS URLs
+	if strings.HasPrefix(lowerContent, "http://") || strings.HasPrefix(lowerContent, "https://") {
+		return false
+	}
+
+	// File protocol
+	if strings.HasPrefix(lowerContent, "file://") {
+		pathPart := content[7:]
+		return len(pathPart) > 1 && hasValidPathStructure(pathPart)
+	}
+
+	// SMB/CIFS protocol
+	if strings.HasPrefix(lowerContent, "smb://") {
+		pathPart := content[6:]
+		return len(pathPart) > 1 && hasValidPathStructure(pathPart)
+	}
+
+	// FTP with file path
+	if strings.HasPrefix(lowerContent, "ftp://") {
+		pathPart := content[6:]
+		if slashIndex := strings.Index(pathPart, "/"); slashIndex > 0 {
+			actualPath := pathPart[slashIndex:]
+			return hasValidPathStructure(actualPath)
+		}
+	}
+
+	return false
+}
+
+// ================================
+// STRUCTURAL VALIDATION
+// ================================
+
+// containsPathSeparator checks if content contains valid path separators
+func containsPathSeparator(content string) bool {
+	return strings.Contains(content, "/") || strings.Contains(content, "\\")
+}
+
+// countValidPathSegments counts meaningful path segments
+func countValidPathSegments(content string, separator string) int {
+	parts := strings.Split(content, separator)
+	meaningfulParts := 0
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if len(part) > 0 && part != "." && part != ".." {
+			meaningfulParts++
+		}
+	}
+
+	return meaningfulParts
+}
+
+// hasFileExtension checks if content has a valid file extension
+func hasFileExtension(content string) bool {
+	// Use Go's filepath.Ext for standard detection
+	ext := filepath.Ext(content)
+	if len(ext) > 1 && len(ext) <= 6 {
+		return true
+	}
+
+	// Use regex for additional patterns
+	return fileExtensionRe.MatchString(content)
+}
+
+// hasValidPathStructure validates the overall path structure
+func hasValidPathStructure(pathStr string) bool {
+	if len(pathStr) < 2 {
+		return false
+	}
+
+	// Check for path separators
+	if !containsPathSeparator(pathStr) {
+		return false
+	}
+
+	// Determine separator type
+	separator := "/"
+	if strings.Contains(pathStr, "\\") {
+		separator = "\\"
+	}
+
+	// Count meaningful segments
+	meaningfulParts := countValidPathSegments(pathStr, separator)
+	if meaningfulParts < 2 {
+		return false
+	}
+
+	// Check for file extension (optional but helpful)
+	hasExt := hasFileExtension(pathStr)
+
+	// More lenient requirements:
+	// - If has extension, accept with 2+ parts
+	// - If no extension, require 3+ parts OR known path patterns
+	if hasExt {
+		return true
+	}
+
+	// For paths without extensions, be more lenient
+	if meaningfulParts >= 3 {
+		return true
+	}
+
+	// Special cases for known path patterns
+	lowerPath := strings.ToLower(pathStr)
+
+	// Windows common directories
+	windowsDirs := []string{
+		"program files", "windows", "users", "temp", "system32", "documents", "programdata",
+		"desktop", "downloads", "music", "pictures", "videos", "appdata", "roaming", "public",
+		"inetpub", "wwwroot", "node_modules", "npm",
+	}
+	for _, dir := range windowsDirs {
+		if strings.Contains(lowerPath, dir) {
+			return true
+		}
+	}
+
+	// Unix system directories
+	if strings.HasPrefix(pathStr, "/") {
+		unixDirs := []string{
+			"/bin/", "/etc/", "/var/", "/usr/", "/opt/", "/home/", "/tmp/", "/lib/",
+			"/proc/", "/dev/", "/sys/", "/run/", "/srv/", "/mnt/", "/media/", "/boot/",
+			"/Applications/", "/Library/", "/System/", "/Users/",
+		}
+		for _, dir := range unixDirs {
+			if strings.Contains(lowerPath, dir) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// isValidPathCharacter checks if a character is valid in file paths
+func isValidPathCharacter(r rune) bool {
+	return (r >= 'a' && r <= 'z') ||
+		(r >= 'A' && r <= 'Z') ||
+		(r >= '0' && r <= '9') ||
+		r == '/' || r == '\\' || r == ':' || r == '.' ||
+		r == '-' || r == '_' || r == ' ' || r == '~'
+}
+
+// hasReasonableCharacterDistribution checks character distribution for path-like content
+func hasReasonableCharacterDistribution(content string) bool {
+	if len(content) == 0 {
+		return false
+	}
+
+	validChars := 0
+	for _, r := range content {
+		if isValidPathCharacter(r) {
+			validChars++
+		}
+	}
+
+	// At least 70% of characters should be valid path characters
+	return float64(validChars)/float64(len(content)) >= 0.7
+}
+
+// ================================
+// MAIN PATH DETECTION
+// ================================
+
+// isLikelyFilePath determines if a string content looks like a file path
+// using a structured, layer-based approach
+func isLikelyFilePath(content string) bool {
+	if len(content) < 2 {
+		return false
+	}
+
+	// EARLY STRONG EXCLUSIONS: HTTP/HTTPS URLs
+	lowerContent := strings.ToLower(content)
+	if strings.HasPrefix(lowerContent, "http://") || strings.HasPrefix(lowerContent, "https://") {
+		return false
+	}
+
+	// Early exclude FTP URLs without file paths
+	if strings.HasPrefix(lowerContent, "ftp://") && !strings.Contains(content[6:], "/") {
+		return false
+	}
+
+	// Early exclusion filters
+	if hasExcessiveEscapeSequences(content) {
+		return false
+	}
+
+	if isLikelyTextBlob(content) {
+		return false
+	}
+
+	if isBase64String(content) {
+		return false
+	}
+
+	if hasURLEncoding(content) {
+		return false
+	}
+
+	// Format-specific detection (high confidence)
+	if isURLPath(content) {
+		return true
+	}
+
+	if isWindowsAbsolutePath(content) {
+		return true
+	}
+
+	if isUNCPath(content) {
+		return true
+	}
+
+	if isUnixAbsolutePath(content) {
+		return true
+	}
+
+	// Additional pattern detection for common paths
+	// Check for common Windows directory patterns
+	windowsPatterns := []string{
+		// System directories
+		"program files", "system32", "windows\\", "programdata",
+		// User directories
+		"users\\", "documents", "desktop", "downloads", "music", "pictures", "videos", "appdata", "roaming", "public",
+		// System functional directories
+		"temp\\", "fonts", "startup", "sendto", "recent", "nethood", "cookies", "cache", "history", "favorites", "templates",
+	}
+	for _, pattern := range windowsPatterns {
+		if strings.Contains(lowerContent, pattern) && containsPathSeparator(content) {
+			return true
+		}
+	}
+
+	// Check for Unix system directory patterns
+	if strings.Contains(content, "/") {
+		unixPatterns := []string{
+			// Standard Unix directories
+			"/bin/", "/etc/", "/var/", "/usr/", "/opt/", "/home/", "/tmp/", "/lib/", "/lib64/",
+			// System directories
+			"/proc/", "/dev/", "/sys/", "/run/", "/srv/", "/mnt/", "/media/", "/boot/", "/snap/",
+			// Application and data directories
+			"/usr/share/", "/usr/local/", "/usr/src/", "/var/log/", "/var/lib/", "/var/cache/", "/var/spool/",
+			// macOS specific directories
+			"/Applications/", "/Library/", "/System/", "/Users/",
+		}
+		for _, pattern := range unixPatterns {
+			if strings.Contains(lowerContent, pattern) {
+				return true
+			}
+		}
+	}
+
+	// Structural validation for relative paths
+	if !containsPathSeparator(content) {
+		return false
+	}
+
+	// Relaxed check for simple backup/config files with common extensions
+	if hasFileExtension(content) {
+		commonFileExts := []string{
+			// Configuration files
+			".config", ".cfg", ".ini", ".conf", ".properties", ".toml",
+			// Data formats
+			".json", ".xml", ".yml", ".yaml", ".csv", ".tsv",
+			// Backup and temporary files
+			".backup", ".bak", ".old", ".tmp", ".temp", ".swp", ".~",
+			// Log and debug files
+			".log", ".out", ".err", ".debug", ".trace",
+			// Database files
+			".db", ".sqlite", ".sqlite3", ".mdb",
+			// Document files
+			".txt", ".md", ".readme", ".doc", ".docx", ".pdf",
+			// Archive files
+			".zip", ".tar", ".gz", ".rar", ".7z", ".bz2", ".xz",
+			// Code files
+			".js", ".ts", ".py", ".go", ".java", ".cpp", ".c", ".h", ".cs", ".php", ".rb", ".rs",
+			// Media files
+			".mp3", ".mp4", ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp", ".svg", ".ico", ".mp3", ".mp4", ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp", ".svg", ".ico",
+			// Data files
+			".dat", ".bin", ".raw", ".dump",
+		}
+		for _, ext := range commonFileExts {
+			if strings.HasSuffix(lowerContent, ext) {
+				return true
+			}
+		}
+	}
+
+	if !hasReasonableCharacterDistribution(content) {
+		return false
+	}
+
+	return hasValidPathStructure(content)
+}
+
+// analyzePotentialFilePath analyzes a portion of text to determine if it contains file paths
+// This function has been optimized for structural detection
+func analyzePotentialFilePath(text *[]rune, startPos int) bool {
+	if startPos >= len(*text) || (*text)[startPos] != '"' {
+		return false
+	}
+
+	// Extract string content
+	i := startPos + 1
+	var contentBuilder strings.Builder
+	hasPathSeparator := false
+
+	// Collect content until closing quote (with reasonable limit)
+	for i < len(*text) && i < startPos+150 {
+		char := (*text)[i]
+
+		if char == '"' {
+			break
+		}
+
+		// Track path separators
+		if char == '\\' || char == '/' {
+			hasPathSeparator = true
+		}
+
+		// Handle escape sequences for path detection
+		if char == '\\' && i+1 < len(*text) {
+			nextChar := (*text)[i+1]
+			switch nextChar {
+			case '"', '\\', '/', 'b', 'f', 'n', 'r', 't':
+				// Preserve escape sequences as-is for path analysis
+				contentBuilder.WriteRune(char)
+				contentBuilder.WriteRune(nextChar)
+				i += 2
+				continue
+			case 'u':
+				// Unicode escape
+				if i+5 < len(*text) {
+					for j := 0; j < 6; j++ {
+						contentBuilder.WriteRune((*text)[i+j])
+					}
+					i += 6
+					continue
+				}
+			}
+		}
+
+		contentBuilder.WriteRune(char)
+		i++
+	}
+
+	content := contentBuilder.String()
+
+	// Pre-validation checks
+	if len(content) < 3 {
+		return false
+	}
+
+	if !hasPathSeparator {
+		return false
+	}
+
+	return isLikelyFilePath(content)
+}

--- a/lib/json/json.go
+++ b/lib/json/json.go
@@ -40,6 +40,8 @@ func LoadModule() (starlark.StringDict, error) {
 				"try_path":   starlark.NewBuiltin(ModuleName+".try_path", generateJsonPath(true)),
 				"eval":       starlark.NewBuiltin(ModuleName+".eval", generateJsonEval(false)),
 				"try_eval":   starlark.NewBuiltin(ModuleName+".try_eval", generateJsonEval(true)),
+				"repair":     starlark.NewBuiltin(ModuleName+".repair", generateRepair(false)),
+				"try_repair": starlark.NewBuiltin(ModuleName+".try_repair", generateRepair(true)),
 			},
 		}
 		for k, v := range stdjson.Module.Members {

--- a/lib/json/json_test.go
+++ b/lib/json/json_test.go
@@ -870,3 +870,111 @@ func TestJSONPathAndEvalFunctions(t *testing.T) {
 		})
 	}
 }
+
+func TestJSONRepair(t *testing.T) {
+	tests := []struct {
+		name    string
+		script  string
+		wantErr string
+	}{
+		{
+			name: `idempotent: valid JSON returned unchanged`,
+			script: itn.HereDoc(`
+				load('json', 'repair')
+				# already-valid JSON must come back byte-for-byte (no engine mangling)
+				assert.eq(repair('{"a":1,"b":[1,2,3]}'), '{"a":1,"b":[1,2,3]}')
+				assert.eq(repair('[1, 2, 3]'), '[1, 2, 3]')
+				assert.eq(repair('42'), '42')
+				assert.eq(repair('"plain"'), '"plain"')
+				assert.eq(repair('{"big":12345678901234567890}'), '{"big":12345678901234567890}')
+				# a backslash path — jsonrepair would double the backslash; the fast path returns valid input unchanged:
+				assert.eq(repair('{"p":"C:\\\\temp"}'), '{"p":"C:\\\\temp"}')
+				# backticks inside a string value must not trip fence stripping:
+				assert.eq(repair('{"code":"x` + "```" + `y"}'), '{"code":"x` + "```" + `y"}')
+			`),
+		},
+		{
+			name: `repair then decode: pathological inputs`,
+			script: itn.HereDoc(`
+				load('json', 'repair', 'decode')
+				def rd(x):
+					return decode(repair(x))
+				assert.eq(rd('` + "```json\\n" + `{"a": 1}` + "\\n```" + `'), {"a": 1})
+				assert.eq(rd('Sure! here:\n` + "```json\\n" + `{"a": 1}` + "\\n```" + `\nthanks'), {"a": 1})
+				assert.eq(rd('{"users": [{"name": "Ann", "age": 3'), {"users": [{"name": "Ann", "age": 3}]})
+				assert.eq(rd("{'name': 'John'}"), {"name": "John"})
+				assert.eq(rd('{"a": 1, "b": [1,2,3,],}'), {"a": 1, "b": [1, 2, 3]})
+				assert.eq(rd('{"ok": True, "v": None}'), {"ok": True, "v": None})
+				# top-level array (exercises the [ ... ] span branch):
+				assert.eq(rd('[1, 2, 3,]'), [1, 2, 3])
+				# truncated value with an escaped quote (exercises the escape branch):
+				assert.eq(rd('{"q":"a\\"b"'), {"q": 'a"b'})
+			`),
+		},
+		{
+			name: `fenced valid JSON: returns the inner`,
+			script: itn.HereDoc(`
+				load('json', 'repair')
+				assert.eq(repair('` + "```json\\n" + `{"a":1}` + "\\n```" + `'), '{"a":1}')
+			`),
+		},
+		{
+			name: `bare prose: yields a scalar (documented boundary)`,
+			script: itn.HereDoc(`
+				load('json', 'repair', 'decode')
+				# repair returns text; a bare scalar is honest, not an object.
+				# scripts that need a structured result check the decoded type.
+				v = decode(repair('The answer is 42'))
+				assert.eq(type(v) in ('dict', 'list'), False)
+			`),
+		},
+		{
+			name: `try_repair: ok and error`,
+			script: itn.HereDoc(`
+				load('json', 'try_repair')
+				out, err = try_repair('{"a": 1,}')
+				assert.eq(err, None)
+				assert.eq(out, '{"a": 1}')
+				bad, err2 = try_repair(123)
+				assert.eq(bad, None)
+				assert.true(err2 != None)
+				# unrepairable text -> (None, error) rather than aborting:
+				bad2, err3 = try_repair('{,,,}')
+				assert.eq(bad2, None)
+				assert.true(err3 != None)
+			`),
+		},
+		{
+			name: `repair: missing argument`,
+			script: itn.HereDoc(`
+				load('json', 'repair')
+				repair()
+			`),
+			wantErr: `json.repair: missing argument for text`,
+		},
+		{
+			name: `repair: wrong type`,
+			script: itn.HereDoc(`
+				load('json', 'repair')
+				repair(42)
+			`),
+			wantErr: `json.repair: for parameter text: got int, want string`,
+		},
+		{
+			name: `repair: unrepairable input aborts (non-try)`,
+			script: itn.HereDoc(`
+				load('json', 'repair')
+				repair('{,,,}')
+			`),
+			wantErr: `json.repair:`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := itn.ExecModuleWithErrorTest(t, json.ModuleName, json.LoadModule, tt.script, tt.wantErr, nil)
+			if (err != nil) != (tt.wantErr != "") {
+				t.Errorf("json(%q) expects error = '%v', actual error = '%v', result = %v", tt.name, tt.wantErr, err, res)
+			}
+		})
+	}
+}

--- a/lib/json/repair.go
+++ b/lib/json/repair.go
@@ -24,10 +24,10 @@ var fenceRe = regexp.MustCompile("(?s)```(?:json|JSON)?[ \\t]*\\r?\\n?(.*?)```")
 // only genuinely-broken input reaches the repair engine — the vendored
 // jsonrepair can otherwise double-escape some valid escape sequences, so it
 // is never run on text that already parses.
-func generateRepair(try bool) func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	return func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func generateRepair(try bool) func(_ *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return func(_ *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var text string
-		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "text", &text); err != nil {
+		if err := starlark.UnpackArgs(fn.Name(), args, kwargs, "text", &text); err != nil {
 			if try {
 				return starlark.Tuple{none, starlark.String(err.Error())}, nil
 			}
@@ -38,7 +38,7 @@ func generateRepair(try bool) func(thread *starlark.Thread, b *starlark.Builtin,
 			if try {
 				return starlark.Tuple{none, starlark.String(err.Error())}, nil
 			}
-			return none, fmt.Errorf("%s: %w", b.Name(), err)
+			return none, fmt.Errorf("%s: %w", fn.Name(), err)
 		}
 		if try {
 			return starlark.Tuple{starlark.String(out), none}, nil
@@ -85,47 +85,43 @@ func repairText(text string) (string, error) {
 // returned to its end so the repair stage can complete it.
 func firstBalancedSpan(s string) (string, bool) {
 	rs := []rune(s)
-	start := -1
-	var open, clos rune
-	for i, r := range rs {
-		if r == '{' || r == '[' {
-			start, open = i, r
-			if r == '{' {
-				clos = '}'
-			} else {
-				clos = ']'
-			}
-			break
-		}
-	}
+	start, clos := openBracket(rs)
 	if start < 0 {
 		return "", false
 	}
+	open := rs[start]
 	depth, inStr, esc := 0, false, false
 	for i := start; i < len(rs); i++ {
-		r := rs[i]
-		if inStr {
-			switch {
-			case esc:
-				esc = false
-			case r == '\\':
-				esc = true
-			case r == '"':
-				inStr = false
-			}
-			continue
-		}
-		switch r {
-		case '"':
-			inStr = true
-		case open:
+		switch r := rs[i]; {
+		case esc:
+			esc = false // this char is escaped; consume it
+		case inStr && r == '\\':
+			esc = true
+		case r == '"':
+			inStr = !inStr
+		case inStr:
+			// inside a string literal: brackets are not structural
+		case r == open:
 			depth++
-		case clos:
-			depth--
-			if depth == 0 {
+		case r == clos:
+			if depth--; depth == 0 {
 				return string(rs[start : i+1]), true
 			}
 		}
 	}
 	return string(rs[start:]), true // truncated; repair completes it
+}
+
+// openBracket returns the index of the first { or [ in rs and its matching
+// closing rune, or (-1, 0) if neither appears.
+func openBracket(rs []rune) (int, rune) {
+	for i, r := range rs {
+		switch r {
+		case '{':
+			return i, '}'
+		case '[':
+			return i, ']'
+		}
+	}
+	return -1, 0
 }

--- a/lib/json/repair.go
+++ b/lib/json/repair.go
@@ -1,0 +1,131 @@
+package json
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/1set/starlet/lib/json/internal/jsonrepair"
+	"go.starlark.net/starlark"
+)
+
+// fenceRe matches a fenced code block, capturing its inner content. LLM
+// output commonly wraps JSON in ```json ... ``` fences.
+var fenceRe = regexp.MustCompile("(?s)```(?:json|JSON)?[ \\t]*\\r?\\n?(.*?)```")
+
+// generateRepair builds the json.repair / json.try_repair builtins. repair
+// recovers a valid JSON *text* from the messy output models produce — code
+// fences, surrounding prose, single quotes, trailing commas, comments,
+// Python True/None, truncation — for the caller to then json.decode. It
+// returns text (not a value): json.decode(json.repair(x)) is the idiom.
+//
+// Already-valid JSON is returned byte-for-byte unchanged (idempotent), and
+// only genuinely-broken input reaches the repair engine — the vendored
+// jsonrepair can otherwise double-escape some valid escape sequences, so it
+// is never run on text that already parses.
+func generateRepair(try bool) func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var text string
+		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "text", &text); err != nil {
+			if try {
+				return starlark.Tuple{none, starlark.String(err.Error())}, nil
+			}
+			return none, err
+		}
+		out, err := repairText(text)
+		if err != nil {
+			if try {
+				return starlark.Tuple{none, starlark.String(err.Error())}, nil
+			}
+			return none, fmt.Errorf("%s: %w", b.Name(), err)
+		}
+		if try {
+			return starlark.Tuple{starlark.String(out), none}, nil
+		}
+		return starlark.String(out), nil
+	}
+}
+
+// repairText normalizes messy text to valid JSON text.
+func repairText(text string) (string, error) {
+	// Fast path: already-valid JSON is returned unchanged. This makes
+	// repair idempotent on good input and avoids running jsonrepair on it
+	// (the engine is not perfectly idempotent — e.g. it can double a
+	// backslash in some valid escapes).
+	if json.Valid([]byte(strings.TrimSpace(text))) {
+		return text, nil
+	}
+
+	// Level 1: prefer fenced content when a code fence is present.
+	candidate := text
+	if m := fenceRe.FindStringSubmatch(text); m != nil {
+		candidate = m[1]
+	}
+
+	// Level 2: take the first balanced {...} or [...] span (drops prose
+	// around the JSON; the repair engine errors on "preamble + fenced JSON").
+	if span, ok := firstBalancedSpan(candidate); ok {
+		candidate = span
+	}
+
+	// If the extracted candidate already parses, return it as-is rather
+	// than risk the engine mangling valid escapes.
+	if json.Valid([]byte(strings.TrimSpace(candidate))) {
+		return candidate, nil
+	}
+
+	// Level 3: repair (vendored jsonrepair v0.2.2; its go1.19 window is
+	// frozen, so the copy is pinned and behavior is golden-locked).
+	return jsonrepair.JSONRepair(candidate)
+}
+
+// firstBalancedSpan returns the first balanced {...} or [...] substring,
+// honoring quoted strings and escapes. A truncated (never-closed) span is
+// returned to its end so the repair stage can complete it.
+func firstBalancedSpan(s string) (string, bool) {
+	rs := []rune(s)
+	start := -1
+	var open, clos rune
+	for i, r := range rs {
+		if r == '{' || r == '[' {
+			start, open = i, r
+			if r == '{' {
+				clos = '}'
+			} else {
+				clos = ']'
+			}
+			break
+		}
+	}
+	if start < 0 {
+		return "", false
+	}
+	depth, inStr, esc := 0, false, false
+	for i := start; i < len(rs); i++ {
+		r := rs[i]
+		if inStr {
+			switch {
+			case esc:
+				esc = false
+			case r == '\\':
+				esc = true
+			case r == '"':
+				inStr = false
+			}
+			continue
+		}
+		switch r {
+		case '"':
+			inStr = true
+		case open:
+			depth++
+		case clos:
+			depth--
+			if depth == 0 {
+				return string(rs[start : i+1]), true
+			}
+		}
+	}
+	return string(rs[start:]), true // truncated; repair completes it
+}


### PR DESCRIPTION
## What

Adds `json.repair` / `json.try_repair` to the existing **lib/json** module (R1; the foundation for `llm.extract`, R12/PKG-14). This is **two new script-visible functions**, not a new module — they sit alongside `encode`/`decode`/`dumps`/`path`/`eval`.

LLM output rarely round-trips through `json.decode` cleanly: code fences, surrounding prose, single quotes, trailing commas, comments, Python `True`/`None`, and truncation are routine. `repair` recovers valid JSON **text** (idiom: `decode(repair(x))`), so it composes with `decode`'s `default` and the `try_*` variants. Because it returns text, a recovered bare scalar is honest output rather than a forced object.

```python
load('json', 'repair', 'decode')
messy = '''Here is the result:
```json
{'name': 'Ann', 'tags': ['a', 'b',],}
```'''
print(decode(repair(messy)))   # {'name': 'Ann', 'tags': ['a', 'b']}
```

## How

Cascade in `repair.go`:

1. **Valid-JSON fast path** — good input is returned **byte-for-byte unchanged** (idempotent), which also sidesteps the engine's escape-doubling on already-valid input.
2. **Fence stripping** — prefer fenced content when a ```` ```json ```` block is present.
3. **First balanced span** — drop prose around the first `{...}` / `[...]` (truncated spans are returned to their end so repair can complete them).
4. **Repair engine** — the vendored jsonrepair.

## Dependencies / vendoring

The engine is a **pinned, vendored copy of `kaptinlin/jsonrepair` v0.2.2** (MIT) under `lib/json/internal/jsonrepair/`: runtime `.go` only, no `_test.go`, so **`go.sum` gains zero third-party dependencies** (ADR-016 §9.1 — zero-dep earns a core seat). v0.2.2 is the last go1.18/1.19 release (v0.2.3+ jumps to go1.24), so the copy is pinned and golden-locked; `doc.go` records provenance and `codecov.yml` ignores the vendored path.

## Tests / verification

- Tests are a **section in `json_test.go`** (no per-fix file, no third-party test framework — stdlib `testing` + the repo's `ExecModuleWithErrorTest`).
- Idempotency on valid input (byte-identical, including the escape sequence the raw engine would mangle), the pathological-input cascade, the `[...]` / escape / truncation span branches, and the error/arg branches → **`repair.go` at 100%**.
- `go vet` + `gofmt` clean; full-repo `-race -count=2` green; **go1.19 floor green in Docker**.

Refs: R1 / R12 / PKG-14 (`llm.extract` downstream), ADR-016 §9.1.