### PR TITLE
[fix] regex: findall/split return a list, matching Python re

### DIFF
--- a/lib/regex/README.md
+++ b/lib/regex/README.md
@@ -14,16 +14,16 @@ It is the successor to the legacy `re` module (which is frozen): `regex` adds **
 | `search(pattern, string, flags=0)` | first match anywhere → `Match` or `None` |
 | `match(pattern, string, flags=0)` | match anchored at the **start** → `Match` or `None` |
 | `fullmatch(pattern, string, flags=0)` | match the **whole** string → `Match` or `None` |
-| `findall(pattern, string, flags=0)` | all matches as a tuple (Python group shaping, see below) |
+| `findall(pattern, string, flags=0)` | all matches as a list (Python group shaping, see below) |
 | `finditer(pattern, string, flags=0)` | a tuple of `Match` objects |
 | `sub(pattern, repl, string, count=0, flags=0)` | replace matches → string |
 | `subn(pattern, repl, string, count=0, flags=0)` | replace → `(string, count)` |
-| `split(pattern, string, maxsplit=0, flags=0)` | split, **including capture-group text** (Python semantics) |
+| `split(pattern, string, maxsplit=0, flags=0)` | split into a list, **including capture-group text** (Python semantics) |
 | `escape(pattern)` | escape regex metacharacters |
 
 `try_compile` / `try_search` are also provided, returning a `(value, error)` pair instead of aborting the script — the same shape as the `json`/`csv`/`http` modules.
 
-**findall shaping** (matches Python): no capture group → the full match text; one group → that group's text; two or more groups → a tuple of the group texts per match.
+**findall shaping** (matches Python): the result is a **list**; no capture group → the full match text; one group → that group's text; two or more groups → a **tuple** of the group texts per match. (`split` likewise returns a list — the same as Python's `re` and starlet's legacy `re` module.)
 
 **sub replacement**: `repl` is either a string template — `\1`/`\g<name>` reference capture groups, `\n`/`\t`/`\r` are the usual escapes, a literal `$` is preserved — or a function called with each `Match`, returning the replacement string. `count` limits the number of replacements (`0` = all, negative = none).
 

--- a/lib/regex/regex.go
+++ b/lib/regex/regex.go
@@ -315,10 +315,12 @@ func (p *Pattern) doFind(str, kind string) starlark.Value {
 }
 
 // doFindall implements Python findall shaping: no group -> the full matches;
-// one group -> that group's text; several groups -> a tuple per match.
+// one group -> that group's text; several groups -> a tuple per match. The
+// outer container is a list, matching Python's re.findall (and the legacy re
+// module); only the per-match multi-group element stays a tuple.
 func (p *Pattern) doFindall(str string) starlark.Value {
 	ng := p.search.NumSubexp()
-	var out starlark.Tuple
+	var out []starlark.Value
 	for _, m := range p.search.FindAllStringSubmatchIndex(str, -1) {
 		switch ng {
 		case 0:
@@ -333,7 +335,7 @@ func (p *Pattern) doFindall(str string) starlark.Value {
 			out = append(out, grp)
 		}
 	}
-	return out
+	return starlark.NewList(out)
 }
 
 func (p *Pattern) doFinditer(str string) starlark.Value {
@@ -347,10 +349,11 @@ func (p *Pattern) doFinditer(str string) starlark.Value {
 }
 
 // doSplit implements Python split: the text of capture groups is included in
-// the result. A non-positive maxsplit means no limit.
+// the result. A non-positive maxsplit means no limit. The result is a list,
+// matching Python's re.split (and the legacy re module).
 func (p *Pattern) doSplit(str string, maxsplit int) starlark.Value {
 	ng := p.search.NumSubexp()
-	var out starlark.Tuple
+	var out []starlark.Value
 	last := 0
 	n := 0
 	for _, m := range p.search.FindAllStringSubmatchIndex(str, -1) {
@@ -365,7 +368,7 @@ func (p *Pattern) doSplit(str string, maxsplit int) starlark.Value {
 		n++
 	}
 	out = append(out, starlark.String(str[last:]))
-	return out
+	return starlark.NewList(out)
 }
 
 // doSub replaces matches. repl is either a string template (Python \1 /

--- a/lib/regex/regex_test.go
+++ b/lib/regex/regex_test.go
@@ -47,10 +47,11 @@ func TestLoadModule_Regex(t *testing.T) {
 			name: `findall: python shaping by group count`,
 			script: itn.HereDoc(`
 				load('regex', 'findall')
-				assert.eq(findall(r'\d+', 'a1 b22 c333'), ('1', '22', '333'))
-				assert.eq(findall(r'(\w)(\d)', 'a1 b2'), (('a', '1'), ('b', '2')))
-				assert.eq(findall(r'x(\d)', 'x1 x2'), ('1', '2'))
-				assert.eq(findall('z', 'abc'), ())
+				assert.eq(findall(r'\d+', 'a1 b22 c333'), ['1', '22', '333'])
+				assert.eq(type(findall(r'\d+', 'a1 b22 c333')), 'list')
+				assert.eq(findall(r'(\w)(\d)', 'a1 b2'), [('a', '1'), ('b', '2')])
+				assert.eq(findall(r'x(\d)', 'x1 x2'), ['1', '2'])
+				assert.eq(findall('z', 'abc'), [])
 			`),
 		},
 		{
@@ -88,7 +89,7 @@ func TestLoadModule_Regex(t *testing.T) {
 			script: itn.HereDoc(`
 				load('regex', 'search', 'findall', 'I', 'M', 'S')
 				assert.eq(search('hello', 'HELLO', I).group(0), 'HELLO')
-				assert.eq(findall('^x', 'x\nx\ny', M), ('x', 'x'))
+				assert.eq(findall('^x', 'x\nx\ny', M), ['x', 'x'])
 				assert.eq(search('a.b', 'a\nb', S).group(0), 'a\nb')
 				assert.eq(search('a.b', 'a\nb'), None)
 			`),
@@ -125,9 +126,27 @@ func TestLoadModule_Regex(t *testing.T) {
 			name: `split: includes capture groups, maxsplit`,
 			script: itn.HereDoc(`
 				load('regex', 'split')
-				assert.eq(split(r'\s+', 'a b  c'), ('a', 'b', 'c'))
-				assert.eq(split(r'(\s+)', 'a b'), ('a', ' ', 'b'))
-				assert.eq(split(',', 'a,b,c', 1), ('a', 'b,c'))
+				assert.eq(split(r'\s+', 'a b  c'), ['a', 'b', 'c'])
+				assert.eq(split(r'(\s+)', 'a b'), ['a', ' ', 'b'])
+				assert.eq(split(',', 'a,b,c', 1), ['a', 'b,c'])
+			`),
+		},
+		{
+			name: `regression: findall/split return list (Python re + legacy re parity)`,
+			script: itn.HereDoc(`
+				load('regex', 'findall', 'split', 'compile')
+				# Python re and the legacy re module return lists here; guard
+				# against silently regressing to a tuple.
+				assert.eq(type(findall(r'\w', 'ab')), 'list')
+				assert.eq(type(findall(r'(\w)(\d)', 'a1')), 'list')
+				assert.eq(type(findall(r'(\w)(\d)', 'a1')[0]), 'tuple')
+				assert.eq(type(split(r',', 'a,b')), 'list')
+				assert.eq(type(compile(r'\w').findall('ab')), 'list')
+				assert.eq(type(compile(r',').split('a,b')), 'list')
+				# list-only operations work on the result:
+				r = findall(r'\d', '1 2 3')
+				r.append('4')
+				assert.eq(r, ['1', '2', '3', '4'])
 			`),
 		},
 		{
@@ -147,7 +166,7 @@ func TestLoadModule_Regex(t *testing.T) {
 				assert.eq(p.pattern, r'(?P<n>\d+)')
 				assert.eq(p.groups, 1)
 				assert.eq(p.search('x42').group('n'), '42')
-				assert.eq(p.findall('1 2 3'), ('1', '2', '3'))
+				assert.eq(p.findall('1 2 3'), ['1', '2', '3'])
 				assert.eq(p.sub('#', 'a1b2'), 'a#b#')
 				assert.true(p.match('5x') != None)
 				assert.eq(p.match('x5'), None)
@@ -286,7 +305,7 @@ func TestLoadModule_Regex(t *testing.T) {
 			script: itn.HereDoc(`
 				load('regex', 'compile')
 				p = compile(r'(\w)(\d)')
-				assert.eq(p.findall('a1 b2'), (('a', '1'), ('b', '2')))
+				assert.eq(p.findall('a1 b2'), [('a', '1'), ('b', '2')])
 				assert.eq(p.finditer('a1')[0].group(2), '1')
 				assert.eq(p.split('a1xb2', 1)[0], '')
 				assert.eq(p.subn('#', 'a1b2'), ('##', 2))


### PR DESCRIPTION
## Problem

`findall` and `split` returned a Starlark **tuple**, but Python's `re` — and starlet's own **legacy `re` module** — return a **list**. The difference is invisible under iteration / indexing / `len`, but surfaces on list-only operations (`.append()`) and `type()` checks. That is precisely the "same name, different shape" trap that confuses callers coming from Python or migrating off `re`.

Differential evidence (same 25 ops in CPython `re` vs starlet `regex`): everything matched — anchoring, group shaping, `\1`/`\g<name>` backreferences, flags (`I`/`M`/`S` even share Python's `2`/`8`/`16` values), named groups, `None` for non-participating groups, and RE2's genuine limits (lookaround / in-pattern backrefs) failing to **compile** with a clear error. The **only** divergence was the `findall`/`split` container type.

## Fix

`doFindall` / `doSplit` now return `starlark.NewList`:

- Outer container → **list** (Python `re.findall` / `re.split`, and legacy `re`).
- Per-match multi-group element → **tuple** (Python returns a list *of tuples*).
- `groups()` / `group(*names)` / `subn` → still **tuples** (Python does too).
- `finditer` → left as-is: Python's `finditer` is a lazy iterator, and a tuple of `Match` objects is the closest immutable analogue.

## Regression coverage

A dedicated case pins `type(findall(...)) == 'list'`, the inner tuple for multi-group matches, `type(split(...)) == 'list'` in both module and `Pattern` forms, and a list-only `append` on the result — so the shape can't quietly regress. Existing goldens updated tuple → list.

`doFindall`/`doSplit` at 100%; `gofmt`/`vet` clean; `-race -count=2` and the **go1.19 floor (Docker)** green.

Refs: ADR-011 (regex module); follow-up to #153.