### PR TITLE
[feat] serial: lossless data-value serialization (bytes/set/tuple/bigint/time)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Inspired by the [*Starlight*](https://github.com/starlight-go/starlight) and [*S
 | [`re`](/lib/re)                   | [![godoc](https://pkg.go.dev/badge/github.com/1set/starlet/lib/re.svg)](https://pkg.go.dev/github.com/1set/starlet/lib/re)                   | Regular expression functions for Starlark (legacy, frozen)    |
 | [`regex`](/lib/regex)             | [![godoc](https://pkg.go.dev/badge/github.com/1set/starlet/lib/regex.svg)](https://pkg.go.dev/github.com/1set/starlet/lib/regex)             | Python-style regex (RE2) with Match objects, flags, named groups |
 | [`runtime`](/lib/runtime)         | [![godoc](https://pkg.go.dev/badge/github.com/1set/starlet/lib/runtime.svg)](https://pkg.go.dev/github.com/1set/starlet/lib/runtime)         | Provides Go and app runtime information                       |
+| [`serial`](/lib/serial)           | [![godoc](https://pkg.go.dev/badge/github.com/1set/starlet/lib/serial.svg)](https://pkg.go.dev/github.com/1set/starlet/lib/serial)           | Lossless data-value serialization (bytes/set/tuple/bigint/time) |
 | [`string`](/lib/string)           | [![godoc](https://pkg.go.dev/badge/github.com/1set/starlet/lib/string.svg)](https://pkg.go.dev/github.com/1set/starlet/lib/string)           | Constants and functions to manipulate strings                 |
 
 For extensive documentation on each library, please refer to the respective README files in the [`lib`](/lib) directory. Additionally, *Starlet* includes an array of official modules. You can explore all provided modules by using [`GetAllBuiltinModuleNames()`](https://pkg.go.dev/github.com/1set/starlet#GetAllBuiltinModuleNames) method.
@@ -103,7 +104,7 @@ This may output:
 ```
 Starlark: Hello, Starlet!
 Go: Hello, Starlet!
-Modules: [atom base64 csv file go_idiomatic hashlib http json log math net path random re regex runtime stats string struct time]
+Modules: [atom base64 csv file go_idiomatic hashlib http json log math net path random re regex runtime serial stats string struct time]
 ```
 
 Use CLI to interact with the read-eval-print loop (REPL):

--- a/config.go
+++ b/config.go
@@ -19,6 +19,7 @@ import (
 	libre "github.com/1set/starlet/lib/re"
 	libregex "github.com/1set/starlet/lib/regex"
 	librt "github.com/1set/starlet/lib/runtime"
+	libserial "github.com/1set/starlet/lib/serial"
 	libstat "github.com/1set/starlet/lib/stats"
 	libstr "github.com/1set/starlet/lib/string"
 	stdmath "go.starlark.net/lib/math"
@@ -48,22 +49,23 @@ var allBuiltinModules = ModuleLoaderMap{
 		}, nil
 	},
 	// add third-party modules
-	libatom.ModuleName:  libatom.LoadModule,
-	libb64.ModuleName:   libb64.LoadModule,
-	libcsv.ModuleName:   libcsv.LoadModule,
-	libfile.ModuleName:  libfile.LoadModule,
-	libhash.ModuleName:  libhash.LoadModule,
-	libhttp.ModuleName:  libhttp.LoadModule,
-	libnet.ModuleName:   libnet.LoadModule,
-	libjson.ModuleName:  libjson.LoadModule,
-	liblog.ModuleName:   liblog.LoadModule,
-	libpath.ModuleName:  libpath.LoadModule,
-	librand.ModuleName:  librand.LoadModule,
-	libre.ModuleName:    libre.LoadModule,
-	libregex.ModuleName: libregex.LoadModule,
-	librt.ModuleName:    librt.LoadModule,
-	libstr.ModuleName:   libstr.LoadModule,
-	libstat.ModuleName:  libstat.LoadModule,
+	libatom.ModuleName:   libatom.LoadModule,
+	libb64.ModuleName:    libb64.LoadModule,
+	libcsv.ModuleName:    libcsv.LoadModule,
+	libfile.ModuleName:   libfile.LoadModule,
+	libhash.ModuleName:   libhash.LoadModule,
+	libhttp.ModuleName:   libhttp.LoadModule,
+	libnet.ModuleName:    libnet.LoadModule,
+	libjson.ModuleName:   libjson.LoadModule,
+	liblog.ModuleName:    liblog.LoadModule,
+	libpath.ModuleName:   libpath.LoadModule,
+	librand.ModuleName:   librand.LoadModule,
+	libre.ModuleName:     libre.LoadModule,
+	libregex.ModuleName:  libregex.LoadModule,
+	librt.ModuleName:     librt.LoadModule,
+	libserial.ModuleName: libserial.LoadModule,
+	libstr.ModuleName:    libstr.LoadModule,
+	libstat.ModuleName:   libstat.LoadModule,
 }
 
 // GetAllBuiltinModuleNames returns a list of all builtin module names.
@@ -180,6 +182,7 @@ var builtinModuleCapabilities = map[string]ModuleCapability{
 	"re":           CapPure,
 	"regex":        CapPure,
 	"runtime":      CapProcess, // exposes host identity, directories, process info
+	"serial":       CapPure,
 	"stats":        CapPure,
 	"string":       CapPure,
 	"struct":       CapPure,

--- a/lib/serial/README.md
+++ b/lib/serial/README.md
@@ -1,0 +1,63 @@
+# serial
+
+`serial` serializes Starlark **data values** to and from a compact JSON envelope, round-tripping the types plain JSON cannot: `bytes`, `set`, `tuple`, arbitrary-precision `int`, `time`, and dicts with **non-string keys**. It is the persistence companion to the `json` module — where `json.encode`/`decode` speak the JSON subset, `serial.dumps`/`loads` preserve the full Starlark data shape so a value written by one script reads back identically in another (caches, content-addressed keys, cross-run state).
+
+## The contract: lossless, or a clear error — never silently lossy
+
+A value either round-trips **losslessly** or `dumps` fails with an **actionable error**. There is no quietly-lossy middle ground, because flattening an object would drop its type identity, methods, or live host binding without telling you.
+
+**Round-trips losslessly** — `None`, `bool`, `int` (including big integers), finite `float`, `str`, `bytes`, `list`, `tuple`, `dict` (string-keyed and non-string-keyed), `set`, `time`.
+
+**Rejected with an error** (convert to data first, or store differently):
+
+| value | why | what to do |
+|---|---|---|
+| function / lambda / builtin | code/closures can't be serialized | store the `.star` script and `load()` it ("persist data, replay code") |
+| `struct` | the constructor / type identity can't be persisted | convert it to a dict first |
+| host Go objects (Go-backed wrappers) | the Go type, methods and live binding would be lost | convert to a dict on the host side first |
+| non-finite `float` (`NaN`, `±Inf`) | JSON has no representation | guard before dumping |
+| a value that refers to itself (cycle) | infinite structure | break the cycle |
+
+This directly answers "will serializing a complex object lose information?" — serial won't let you serialize an object at all; it tells you to flatten it first, so nothing is dropped behind your back.
+
+## Functions
+
+| function | description |
+|---|---|
+| `dumps(value) string` | serialize a data value to a JSON-envelope string (deterministic; usable as a cache key) |
+| `loads(s) value` | reconstruct the value from a `dumps` string |
+| `try_dumps(value) tuple` | `dumps` variant returning `(result, error)` instead of aborting |
+| `try_loads(s) tuple` | `loads` variant returning `(result, error)` |
+
+`loads` returns a fresh, **unfrozen** value (the same as `json.decode`), so scripts can read or mutate the result.
+
+## Encoding
+
+Non-JSON-native values are wrapped in a `{"$t": <tag>, "v": <payload>}` envelope: `bytes` (base64), `set`, `tuple`, `bigint` (decimal string), `time` (RFC 3339), and `mapkv` for a dict with non-string keys (a list of `[key, value]` pairs). A real dict that itself contains a `"$t"` key is wrapped in an `object` envelope so it is never mistaken for a tagged value on the way back. Output is **deterministic**: object keys are sorted and set elements are ordered by their encoded form, so the same value always dumps to the same bytes.
+
+## Examples
+
+**Round-trip the types JSON drops**
+
+```python
+load('serial', 'dumps', 'loads')
+v = {'id': 2**80, 'tags': set(['a', 'b']), 'raw': b'\x00\x01', 'pair': (1, 2)}
+assert loads(dumps(v)) == v
+```
+
+**Deterministic, usable as a cache key**
+
+```python
+load('serial', 'dumps')
+print(dumps({'b': 2, 'a': 1}))
+# Output: {"a":1,"b":2}
+```
+
+**Handle failure without aborting**
+
+```python
+load('serial', 'try_dumps')
+out, err = try_dumps(lambda x: x)
+print(out, err)
+# Output: None serial.dumps: cannot serialize function: it is code — store the .star script and load() it instead
+```

--- a/lib/serial/serial.go
+++ b/lib/serial/serial.go
@@ -1,0 +1,472 @@
+// Package serial defines a Starlark module that serializes data values to and
+// from a JSON envelope, round-tripping the types plain JSON cannot: bytes,
+// set, tuple, big integers, time, and dicts with non-string keys.
+//
+// The contract is deliberately strict: a value either round-trips losslessly
+// or dumps fails with an actionable error — there is no silently-lossy middle
+// ground. Code (functions/builtins), host objects (structs, Go-backed
+// wrappers), non-finite floats, and reference cycles are rejected rather than
+// flattened, because flattening them would quietly drop type identity,
+// methods, or live bindings. To persist behavior, store the .star script and
+// load() it; to persist a struct/host object, convert it to a dict first.
+package serial
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math"
+	"math/big"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	startime "go.starlark.net/lib/time"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+// ModuleName defines the expected name for this Module when used in starlark's
+// load() function, eg: load('serial', 'dumps')
+const ModuleName = "serial"
+
+// Envelope keys and type tags.
+const (
+	tagKey = "$t"
+	valKey = "v"
+
+	tagBytes  = "bytes"
+	tagSet    = "set"
+	tagTuple  = "tuple"
+	tagBigint = "bigint"
+	tagTime   = "time"
+	tagMapKV  = "mapkv"  // a dict with non-string keys, as [[k, v], ...]
+	tagObject = "object" // escape for a real dict that itself contains a "$t" key
+)
+
+var (
+	none   = starlark.None
+	once   sync.Once
+	module starlark.StringDict
+)
+
+// LoadModule loads the serial module. It is concurrency-safe and idempotent.
+func LoadModule() (starlark.StringDict, error) {
+	once.Do(func() {
+		module = starlark.StringDict{
+			ModuleName: &starlarkstruct.Module{
+				Name: ModuleName,
+				Members: starlark.StringDict{
+					"dumps":     starlark.NewBuiltin(ModuleName+".dumps", generateDumps(false)),
+					"try_dumps": starlark.NewBuiltin(ModuleName+".try_dumps", generateDumps(true)),
+					"loads":     starlark.NewBuiltin(ModuleName+".loads", generateLoads(false)),
+					"try_loads": starlark.NewBuiltin(ModuleName+".try_loads", generateLoads(true)),
+				},
+			},
+		}
+	})
+	return module, nil
+}
+
+func env(tag string, v interface{}) map[string]interface{} {
+	return map[string]interface{}{tagKey: tag, valKey: v}
+}
+
+// generateDumps builds serial.dumps / serial.try_dumps. dumps walks the value
+// directly (never via Unmarshal, which would collapse type information) and
+// returns deterministic JSON text suitable for use as a cache key.
+func generateDumps(try bool) func(*starlark.Thread, *starlark.Builtin, starlark.Tuple, []starlark.Tuple) (starlark.Value, error) {
+	return func(_ *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var v starlark.Value
+		if err := starlark.UnpackArgs(fn.Name(), args, kwargs, "value", &v); err != nil {
+			return failDumps(try, err, fn, false)
+		}
+		enc, err := encode(v, map[uintptr]bool{})
+		if err != nil {
+			return failDumps(try, err, fn, true)
+		}
+		b, err := json.Marshal(enc)
+		if err != nil {
+			return failDumps(try, err, fn, true)
+		}
+		if try {
+			return starlark.Tuple{starlark.String(b), none}, nil
+		}
+		return starlark.String(b), nil
+	}
+}
+
+func failDumps(try bool, err error, fn *starlark.Builtin, wrap bool) (starlark.Value, error) {
+	if try {
+		return starlark.Tuple{none, starlark.String(err.Error())}, nil
+	}
+	if wrap {
+		return none, fmt.Errorf("%s: %w", fn.Name(), err)
+	}
+	return none, err
+}
+
+// generateLoads builds serial.loads / serial.try_loads. The result is a fresh,
+// unfrozen value (mirroring json.decode), so scripts can read or mutate it.
+func generateLoads(try bool) func(*starlark.Thread, *starlark.Builtin, starlark.Tuple, []starlark.Tuple) (starlark.Value, error) {
+	return func(_ *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var s string
+		if err := starlark.UnpackArgs(fn.Name(), args, kwargs, "s", &s); err != nil {
+			if try {
+				return starlark.Tuple{none, starlark.String(err.Error())}, nil
+			}
+			return none, err
+		}
+		dec := json.NewDecoder(strings.NewReader(s))
+		dec.UseNumber()
+		var raw interface{}
+		if err := dec.Decode(&raw); err != nil {
+			if try {
+				return starlark.Tuple{none, starlark.String(err.Error())}, nil
+			}
+			return none, fmt.Errorf("%s: %w", fn.Name(), err)
+		}
+		val, err := decode(raw)
+		if err != nil {
+			if try {
+				return starlark.Tuple{none, starlark.String(err.Error())}, nil
+			}
+			return none, fmt.Errorf("%s: %w", fn.Name(), err)
+		}
+		if try {
+			return starlark.Tuple{val, none}, nil
+		}
+		return val, nil
+	}
+}
+
+// encode converts a Starlark value to a JSON-marshalable Go value. seen tracks
+// list/dict pointers so a reference cycle errors instead of recursing forever.
+func encode(v starlark.Value, seen map[uintptr]bool) (interface{}, error) {
+	switch t := v.(type) {
+	case starlark.NoneType:
+		return nil, nil
+	case starlark.Bool:
+		return bool(t), nil
+	case starlark.Int:
+		if i, ok := t.Int64(); ok {
+			return i, nil
+		}
+		return env(tagBigint, t.String()), nil
+	case starlark.Float:
+		f := float64(t)
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return nil, fmt.Errorf("cannot serialize non-finite float %v", f)
+		}
+		return f, nil
+	case starlark.String:
+		return string(t), nil
+	case starlark.Bytes:
+		return env(tagBytes, base64.StdEncoding.EncodeToString([]byte(t))), nil
+	case startime.Time:
+		return env(tagTime, time.Time(t).Format(time.RFC3339Nano)), nil
+	case *starlark.List:
+		p := reflect.ValueOf(t).Pointer()
+		if seen[p] {
+			return nil, fmt.Errorf("cannot serialize a value that refers to itself (cycle in list)")
+		}
+		seen[p] = true
+		defer delete(seen, p)
+		arr := make([]interface{}, 0, t.Len())
+		for i := 0; i < t.Len(); i++ {
+			e, err := encode(t.Index(i), seen)
+			if err != nil {
+				return nil, err
+			}
+			arr = append(arr, e)
+		}
+		return arr, nil
+	case starlark.Tuple:
+		arr, err := encodeElems(t, seen)
+		if err != nil {
+			return nil, err
+		}
+		return env(tagTuple, arr), nil
+	case *starlark.Set:
+		elems, err := encodeSet(t, seen)
+		if err != nil {
+			return nil, err
+		}
+		return env(tagSet, elems), nil
+	case *starlark.Dict:
+		return encodeDict(t, seen)
+	case *starlark.Function, *starlark.Builtin:
+		return nil, fmt.Errorf("cannot serialize %s: it is code — store the .star script and load() it instead", v.Type())
+	case *starlarkstruct.Struct:
+		return nil, fmt.Errorf("cannot serialize struct: convert it to a dict first (struct identity cannot be persisted)")
+	default:
+		return nil, fmt.Errorf("cannot serialize value of type %s: serial round-trips data, not host objects", v.Type())
+	}
+}
+
+func encodeElems(elems []starlark.Value, seen map[uintptr]bool) ([]interface{}, error) {
+	out := make([]interface{}, 0, len(elems))
+	for _, e := range elems {
+		ee, err := encode(e, seen)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, ee)
+	}
+	return out, nil
+}
+
+// encodeSet encodes a set and sorts the elements by their JSON form so the
+// output is deterministic (a set has no inherent order).
+func encodeSet(s *starlark.Set, seen map[uintptr]bool) ([]interface{}, error) {
+	var elems []interface{}
+	iter := s.Iterate()
+	defer iter.Done()
+	var x starlark.Value
+	for iter.Next(&x) {
+		e, err := encode(x, seen)
+		if err != nil {
+			return nil, err
+		}
+		elems = append(elems, e)
+	}
+	return sortByJSON(elems), nil
+}
+
+// encodeDict encodes a dict. With all-string keys it becomes a JSON object
+// (json.Marshal sorts the keys); with any non-string key it becomes the mapkv
+// tag. A real object carrying a "$t" key is wrapped in the object tag so it is
+// never mistaken for an envelope on the way back.
+func encodeDict(d *starlark.Dict, seen map[uintptr]bool) (interface{}, error) {
+	p := reflect.ValueOf(d).Pointer()
+	if seen[p] {
+		return nil, fmt.Errorf("cannot serialize a value that refers to itself (cycle in dict)")
+	}
+	seen[p] = true
+	defer delete(seen, p)
+
+	keys := d.Keys()
+	allString := true
+	for _, k := range keys {
+		if _, ok := k.(starlark.String); !ok {
+			allString = false
+			break
+		}
+	}
+
+	if allString {
+		m := make(map[string]interface{}, len(keys))
+		hasTag := false
+		for _, k := range keys {
+			ks := string(k.(starlark.String))
+			if ks == tagKey {
+				hasTag = true
+			}
+			val, _, _ := d.Get(k)
+			e, err := encode(val, seen)
+			if err != nil {
+				return nil, err
+			}
+			m[ks] = e
+		}
+		if hasTag {
+			return env(tagObject, m), nil
+		}
+		return m, nil
+	}
+
+	type pair struct {
+		entry []interface{}
+		order string
+	}
+	pairs := make([]pair, 0, len(keys))
+	for _, k := range keys {
+		ke, err := encode(k, seen)
+		if err != nil {
+			return nil, err
+		}
+		val, _, _ := d.Get(k)
+		ve, err := encode(val, seen)
+		if err != nil {
+			return nil, err
+		}
+		kb, _ := json.Marshal(ke)
+		pairs = append(pairs, pair{[]interface{}{ke, ve}, string(kb)})
+	}
+	sort.SliceStable(pairs, func(i, j int) bool { return pairs[i].order < pairs[j].order })
+	out := make([]interface{}, len(pairs))
+	for i, pr := range pairs {
+		out[i] = pr.entry
+	}
+	return env(tagMapKV, out), nil
+}
+
+// sortByJSON orders encoded elements by their marshaled bytes, for determinism.
+func sortByJSON(elems []interface{}) []interface{} {
+	type keyed struct {
+		v     interface{}
+		order string
+	}
+	ks := make([]keyed, len(elems))
+	for i, e := range elems {
+		b, _ := json.Marshal(e)
+		ks[i] = keyed{e, string(b)}
+	}
+	sort.SliceStable(ks, func(i, j int) bool { return ks[i].order < ks[j].order })
+	out := make([]interface{}, len(elems))
+	for i, k := range ks {
+		out[i] = k.v
+	}
+	return out
+}
+
+// decode converts the parsed JSON (json.Number-preserving) back to a Starlark
+// value, interpreting type tags.
+func decode(v interface{}) (starlark.Value, error) {
+	switch t := v.(type) {
+	case nil:
+		return starlark.None, nil
+	case bool:
+		return starlark.Bool(t), nil
+	case json.Number:
+		return numberToValue(t)
+	case string:
+		return starlark.String(t), nil
+	case []interface{}:
+		elems := make([]starlark.Value, len(t))
+		for i, e := range t {
+			ev, err := decode(e)
+			if err != nil {
+				return nil, err
+			}
+			elems[i] = ev
+		}
+		return starlark.NewList(elems), nil
+	case map[string]interface{}:
+		return decodeObject(t)
+	default:
+		return nil, fmt.Errorf("invalid serialized value of type %T", v)
+	}
+}
+
+func decodeObject(m map[string]interface{}) (starlark.Value, error) {
+	tag, ok := m[tagKey].(string)
+	if !ok {
+		return decodeDict(m)
+	}
+	raw := m[valKey]
+	switch tag {
+	case tagBytes:
+		s, _ := raw.(string)
+		b, err := base64.StdEncoding.DecodeString(s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid bytes payload: %w", err)
+		}
+		return starlark.Bytes(b), nil
+	case tagBigint:
+		s, _ := raw.(string)
+		bi, ok := new(big.Int).SetString(s, 10)
+		if !ok {
+			return nil, fmt.Errorf("invalid bigint payload %q", s)
+		}
+		return starlark.MakeBigInt(bi), nil
+	case tagTuple:
+		arr, _ := raw.([]interface{})
+		elems := make([]starlark.Value, len(arr))
+		for i, e := range arr {
+			ev, err := decode(e)
+			if err != nil {
+				return nil, err
+			}
+			elems[i] = ev
+		}
+		return starlark.Tuple(elems), nil
+	case tagSet:
+		arr, _ := raw.([]interface{})
+		set := starlark.NewSet(len(arr))
+		for _, e := range arr {
+			ev, err := decode(e)
+			if err != nil {
+				return nil, err
+			}
+			if err := set.Insert(ev); err != nil {
+				return nil, err
+			}
+		}
+		return set, nil
+	case tagTime:
+		s, _ := raw.(string)
+		tm, err := time.Parse(time.RFC3339Nano, s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid time payload %q: %w", s, err)
+		}
+		return startime.Time(tm), nil
+	case tagMapKV:
+		arr, _ := raw.([]interface{})
+		d := starlark.NewDict(len(arr))
+		for _, pr := range arr {
+			kvp, ok := pr.([]interface{})
+			if !ok || len(kvp) != 2 {
+				return nil, fmt.Errorf("invalid mapkv entry")
+			}
+			kv, err := decode(kvp[0])
+			if err != nil {
+				return nil, err
+			}
+			vv, err := decode(kvp[1])
+			if err != nil {
+				return nil, err
+			}
+			if err := d.SetKey(kv, vv); err != nil {
+				return nil, err
+			}
+		}
+		return d, nil
+	case tagObject:
+		mm, ok := raw.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid object payload")
+		}
+		return decodeDict(mm)
+	default:
+		return nil, fmt.Errorf("unknown type tag %q", tag)
+	}
+}
+
+func decodeDict(m map[string]interface{}) (starlark.Value, error) {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	d := starlark.NewDict(len(m))
+	for _, k := range keys {
+		vv, err := decode(m[k])
+		if err != nil {
+			return nil, err
+		}
+		if err := d.SetKey(starlark.String(k), vv); err != nil {
+			return nil, err
+		}
+	}
+	return d, nil
+}
+
+func numberToValue(n json.Number) (starlark.Value, error) {
+	s := n.String()
+	if !strings.ContainsAny(s, ".eE") {
+		if i, err := n.Int64(); err == nil {
+			return starlark.MakeInt64(i), nil
+		}
+		if bi, ok := new(big.Int).SetString(s, 10); ok {
+			return starlark.MakeBigInt(bi), nil
+		}
+	}
+	f, err := n.Float64()
+	if err != nil {
+		return nil, fmt.Errorf("invalid number %q: %w", s, err)
+	}
+	return starlark.Float(f), nil
+}

--- a/lib/serial/serial_test.go
+++ b/lib/serial/serial_test.go
@@ -1,0 +1,340 @@
+package serial_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/1set/starlet/dataconv"
+	itn "github.com/1set/starlet/internal"
+	"github.com/1set/starlet/lib/serial"
+	startime "go.starlark.net/lib/time"
+	"go.starlark.net/starlark"
+)
+
+func TestLoadModule_Serial(t *testing.T) {
+	type Person struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}
+	t0 := time.Date(2026, 6, 13, 12, 30, 0, 0, time.UTC)
+	pred := starlark.StringDict{
+		"t0": startime.Time(t0),
+		"gs": dataconv.ConvertStruct(&Person{"Ann", 3}, "json"),
+	}
+	tests := []struct {
+		name    string
+		script  string
+		wantErr string
+	}{
+		{
+			name: `round-trip: scalars`,
+			script: itn.HereDoc(`
+				load('serial', 'dumps', 'loads')
+				def rt(x): return loads(dumps(x))
+				assert.eq(rt(None), None)
+				assert.eq(rt(True), True)
+				assert.eq(rt(False), False)
+				assert.eq(rt(0), 0)
+				assert.eq(rt(42), 42)
+				assert.eq(rt(-7), -7)
+				assert.eq(rt(1267650600228229401496703205376), 1267650600228229401496703205376)
+				assert.eq(rt(3.14), 3.14)
+				assert.eq(rt('héllo'), 'héllo')
+				assert.eq(rt(''), '')
+			`),
+		},
+		{
+			name: `round-trip: containers and the five extra types`,
+			script: itn.HereDoc(`
+				load('serial', 'dumps', 'loads')
+				def rt(x): return loads(dumps(x))
+				assert.eq(rt(b'abc'), b'abc')
+				assert.eq(rt([1, 'a', True, None]), [1, 'a', True, None])
+				assert.eq(rt((1, 2)), (1, 2))
+				assert.eq(rt({'a': 1, 'b': [2, 3]}), {'a': 1, 'b': [2, 3]})
+				assert.eq(rt(set([1, 2, 3])), set([1, 2, 3]))
+				assert.eq(rt({1: 'a', (2, 3): 'b'}), {1: 'a', (2, 3): 'b'})
+				assert.eq(rt(t0), t0)
+			`),
+		},
+		{
+			name: `type preservation: tuple stays tuple, bytes stays bytes, set stays set`,
+			script: itn.HereDoc(`
+				load('serial', 'dumps', 'loads')
+				def rt(x): return loads(dumps(x))
+				assert.eq(type(rt((1, 2))), 'tuple')
+				assert.eq(type(rt([1, 2])), 'list')
+				assert.eq(type(rt(b'x')), 'bytes')
+				assert.eq(type(rt(set([1]))), 'set')
+				assert.eq(type(rt(1267650600228229401496703205376)), 'int')
+			`),
+		},
+		{
+			name: `determinism: key order independent, stable golden`,
+			script: itn.HereDoc(`
+				load('serial', 'dumps')
+				assert.eq(dumps({'b': 2, 'a': 1}), dumps({'a': 1, 'b': 2}))
+				assert.eq(dumps({'a': 1, 'b': 2}), '{"a":1,"b":2}')
+				assert.eq(dumps(set([3, 1, 2])), dumps(set([2, 3, 1])))
+			`),
+		},
+		{
+			name: `$t escape: a real dict carrying a $t key round-trips`,
+			script: itn.HereDoc(`
+				load('serial', 'dumps', 'loads')
+				def rt(x): return loads(dumps(x))
+				assert.eq(rt({'$t': 'hello', 'y': 1}), {'$t': 'hello', 'y': 1})
+				assert.true('object' in dumps({'$t': 'x'}))
+			`),
+		},
+		{
+			name: `round-trip: deep nesting mixing every type`,
+			script: itn.HereDoc(`
+				load('serial', 'dumps', 'loads')
+				def rt(x): return loads(dumps(x))
+				v = {'list': [1, (2, 3), set([4])], 'bytes': b'z', 'big': 1180591620717411303424, 'm': {1: 'x'}}
+				assert.eq(rt(v), v)
+			`),
+		},
+		{
+			name: `try_dumps / try_loads: ok and error`,
+			script: itn.HereDoc(`
+				load('serial', 'try_dumps', 'try_loads')
+				out, err = try_dumps(42)
+				assert.eq(err, None)
+				assert.eq(out, '42')
+				bad, e2 = try_dumps(lambda x: x)
+				assert.eq(bad, None)
+				assert.true(e2 != None)
+				val, e3 = try_loads('[1,2,3]')
+				assert.eq(e3, None)
+				assert.eq(val, [1, 2, 3])
+				bad2, e4 = try_loads('not json')
+				assert.eq(bad2, None)
+				assert.true(e4 != None)
+			`),
+		},
+		{
+			name: `error: cannot serialize a function`,
+			script: itn.HereDoc(`
+				load('serial', 'dumps')
+				dumps(lambda x: x)
+			`),
+			wantErr: `it is code`,
+		},
+		{
+			name: `error: cannot serialize a builtin`,
+			script: itn.HereDoc(`
+				load('serial', 'dumps')
+				dumps(dumps)
+			`),
+			wantErr: `it is code`,
+		},
+		{
+			name: `error: reference cycle is reported, not a panic`,
+			script: itn.HereDoc(`
+				load('serial', 'dumps')
+				x = [1]
+				x.append(x)
+				dumps(x)
+			`),
+			wantErr: `cycle`,
+		},
+		{
+			name: `error: non-finite float`,
+			script: itn.HereDoc(`
+				load('serial', 'dumps')
+				dumps(float('inf'))
+			`),
+			wantErr: `non-finite`,
+		},
+		{
+			name: `error: struct must be converted to a dict first`,
+			script: itn.HereDoc(`
+				load('serial', 'dumps')
+				load('struct.star', 'struct')
+				dumps(struct(a=1))
+			`),
+			wantErr: `convert it to a dict`,
+		},
+		{
+			name: `error: host Go object is not data`,
+			script: itn.HereDoc(`
+				load('serial', 'dumps')
+				dumps(gs)
+			`),
+			wantErr: `host objects`,
+		},
+		{
+			name: `error: loads rejects an unknown type tag`,
+			script: itn.HereDoc(`
+				load('serial', 'loads')
+				loads('{"$t":"bogus","v":1}')
+			`),
+			wantErr: `unknown type tag`,
+		},
+		{
+			name: `error: loads rejects invalid JSON`,
+			script: itn.HereDoc(`
+				load('serial', 'loads')
+				loads('{not json')
+			`),
+			wantErr: `serial.loads:`,
+		},
+		{
+			name: `error: dumps missing argument`,
+			script: itn.HereDoc(`
+				load('serial', 'dumps')
+				dumps()
+			`),
+			wantErr: `serial.dumps: missing argument for value`,
+		},
+		{
+			name: `error: loads wrong type`,
+			script: itn.HereDoc(`
+				load('serial', 'loads')
+				loads(42)
+			`),
+			wantErr: `serial.loads: for parameter s: got int, want string`,
+		},
+		{
+			name: `loads: bare big integer and floats (numberToValue branches)`,
+			script: itn.HereDoc(`
+				load('serial', 'loads')
+				assert.eq(loads('123456789012345678901234567890'), 123456789012345678901234567890)
+				assert.eq(loads('3.5'), 3.5)
+				assert.eq(loads('-0.25'), -0.25)
+				assert.eq(loads('1e3'), 1000.0)
+				`),
+		},
+		{
+			name: `error: unserializable inside a list propagates`,
+			script: itn.HereDoc(`
+				load('serial', 'dumps')
+				dumps([1, lambda x: x])
+				`),
+			wantErr: `it is code`,
+		},
+		{
+			name: `error: unserializable inside a tuple propagates`,
+			script: itn.HereDoc(`
+				load('serial', 'dumps')
+				dumps((1, lambda x: x))
+				`),
+			wantErr: `it is code`,
+		},
+		{
+			name: `error: unserializable as a dict value propagates`,
+			script: itn.HereDoc(`
+				load('serial', 'dumps')
+				dumps({'a': lambda x: x})
+				`),
+			wantErr: `it is code`,
+		},
+		{
+			name: `error: unserializable in a non-string-key dict propagates`,
+			script: itn.HereDoc(`
+				load('serial', 'dumps')
+				dumps({1: lambda x: x})
+				`),
+			wantErr: `it is code`,
+		},
+		{
+			name: `error: unserializable inside a set propagates`,
+			script: itn.HereDoc(`
+				load('serial', 'dumps')
+				dumps(set([lambda x: x]))
+				`),
+			wantErr: `it is code`,
+		},
+		{
+			name: `error: loads invalid bytes payload`,
+			script: itn.HereDoc(`
+				load('serial', 'loads')
+				loads('{"$t":"bytes","v":"!!!!"}')
+				`),
+			wantErr: `bytes payload`,
+		},
+		{
+			name: `error: loads invalid bigint payload`,
+			script: itn.HereDoc(`
+				load('serial', 'loads')
+				loads('{"$t":"bigint","v":"x"}')
+				`),
+			wantErr: `invalid bigint`,
+		},
+		{
+			name: `error: loads invalid time payload`,
+			script: itn.HereDoc(`
+				load('serial', 'loads')
+				loads('{"$t":"time","v":"x"}')
+				`),
+			wantErr: `invalid time`,
+		},
+		{
+			name: `error: loads malformed mapkv entry`,
+			script: itn.HereDoc(`
+				load('serial', 'loads')
+				loads('{"$t":"mapkv","v":[[1]]}')
+				`),
+			wantErr: `invalid mapkv`,
+		},
+		{
+			name: `error: loads invalid object payload`,
+			script: itn.HereDoc(`
+				load('serial', 'loads')
+				loads('{"$t":"object","v":5}')
+				`),
+			wantErr: `invalid object payload`,
+		},
+		{
+			name: `error: nested unknown tag propagates through a dict`,
+			script: itn.HereDoc(`
+				load('serial', 'loads')
+				loads('{"k":{"$t":"nope"}}')
+				`),
+			wantErr: `unknown type tag`,
+		},
+		{
+			name: `error: unserializable as a non-string dict key propagates`,
+			script: itn.HereDoc(`
+				load('serial', 'dumps')
+				dumps({(1, lambda x: x): 1})
+				`),
+			wantErr: `it is code`,
+		},
+		{
+			name: `error: loads set with an unhashable element`,
+			script: itn.HereDoc(`
+				load('serial', 'loads')
+				loads('{"$t":"set","v":[[1,2]]}')
+				`),
+			wantErr: `unhashable`,
+		},
+		{
+			name: `error: loads mapkv with an unhashable key`,
+			script: itn.HereDoc(`
+				load('serial', 'loads')
+				loads('{"$t":"mapkv","v":[[[1],"x"]]}')
+				`),
+			wantErr: `unhashable`,
+		},
+		{
+			name: `try_loads: decode error after valid JSON parses`,
+			script: itn.HereDoc(`
+				load('serial', 'try_loads')
+				v, err = try_loads('{"$t":"bogus","v":1}')
+				assert.eq(v, None)
+				assert.true('unknown type tag' in err)
+				`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := itn.ExecModuleWithErrorTest(t, serial.ModuleName, serial.LoadModule, tt.script, tt.wantErr, pred)
+			if (err != nil) != (tt.wantErr != "") {
+				t.Errorf("serial(%q) expects error = %q, got %v", tt.name, tt.wantErr, err)
+			}
+		})
+	}
+}

--- a/lib/serial/serial_test.go
+++ b/lib/serial/serial_test.go
@@ -328,6 +328,65 @@ func TestLoadModule_Serial(t *testing.T) {
 				assert.true('unknown type tag' in err)
 				`),
 		},
+		{
+			name: `try_loads: wrong argument type`,
+			script: itn.HereDoc(`
+				load('serial', 'try_loads')
+				v, err = try_loads(42)
+				assert.eq(v, None)
+				assert.true(err != None)
+				`),
+		},
+		{
+			name: `error: reference cycle through a dict`,
+			script: itn.HereDoc(`
+				load('serial', 'dumps')
+				d = {}
+				d['self'] = d
+				dumps(d)
+				`),
+			wantErr: `cycle`,
+		},
+		{
+			name: `error: bad element inside a list propagates on load`,
+			script: itn.HereDoc(`
+				load('serial', 'loads')
+				loads('[{"$t":"nope"}]')
+				`),
+			wantErr: `unknown type tag`,
+		},
+		{
+			name: `error: bad element inside a tuple propagates on load`,
+			script: itn.HereDoc(`
+				load('serial', 'loads')
+				loads('{"$t":"tuple","v":[{"$t":"nope"}]}')
+				`),
+			wantErr: `unknown type tag`,
+		},
+		{
+			name: `error: bad element inside a set propagates on load`,
+			script: itn.HereDoc(`
+				load('serial', 'loads')
+				loads('{"$t":"set","v":[{"$t":"nope"}]}')
+				`),
+			wantErr: `unknown type tag`,
+		},
+		{
+			name: `error: bad key inside mapkv propagates on load`,
+			script: itn.HereDoc(`
+				load('serial', 'loads')
+				loads('{"$t":"mapkv","v":[[{"$t":"nope"},1]]}')
+				`),
+			wantErr: `unknown type tag`,
+		},
+		{
+			name: `error: bad value inside mapkv propagates on load`,
+			script: itn.HereDoc(`
+				load('serial', 'loads')
+				loads('{"$t":"mapkv","v":[["k",{"$t":"nope"}]]}')
+				`),
+			wantErr: `unknown type tag`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/module_test.go
+++ b/module_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	builtinModules = []string{"atom", "base64", "csv", "file", "go_idiomatic", "hashlib", "http", "json", "log", "math", "net", "path", "random", "re", "regex", "runtime", "stats", "string", "struct", "time"}
+	builtinModules = []string{"atom", "base64", "csv", "file", "go_idiomatic", "hashlib", "http", "json", "log", "math", "net", "path", "random", "re", "regex", "runtime", "serial", "stats", "string", "struct", "time"}
 )
 
 func TestListBuiltinModules(t *testing.T) {


### PR DESCRIPTION
## What

Adds **lib/serial** (R3, ADR-013): `dumps` / `loads` / `try_dumps` / `try_loads` for persisting Starlark **data values** across script runs, round-tripping the types `json` cannot — `bytes`, `set`, `tuple`, arbitrary-precision `int`, `time`, and dicts with **non-string keys**. It is the persistence companion to the `json` module (caches, content-addressed keys, cross-run state); starpkg's `cache` (PKG-10) is meant to reuse this encoding rather than roll its own.

```python
load('serial', 'dumps', 'loads')
v = {'id': 2**80, 'tags': set(['a', 'b']), 'raw': b'\x00\x01', 'pair': (1, 2)}
assert loads(dumps(v)) == v          # the five extra types survive
print(dumps({'b': 2, 'a': 1}))       # {"a":1,"b":2}  — deterministic, cache-key-able
```

## Contract: lossless, or a clear error — never silently lossy

A value either round-trips **losslessly** or `dumps` fails with an **actionable error**. There is no quietly-lossy middle ground, because flattening an object would drop type identity, methods, or a live host binding without telling you. Rejected (not flattened): functions/builtins (code), `struct` (constructor identity), host Go-backed wrappers (Go type + methods + live binding), non-finite floats, and reference cycles.

This was **verified empirically by a spike** against real `GoStruct` / `starlarkstruct` / function / cycle values *before the API was locked*: each is detectable, and each errors cleanly with no panic. It directly answers "will serializing a complex object lose information?" — serial won't let you serialize an object at all; it tells you to flatten it first.

## How

A `{"$t": tag, "v": payload}` envelope carries the extra types (`bytes`→base64, `bigint`→decimal, `time`→RFC 3339, `set`, `tuple`, non-string-key dict→`mapkv` pairs), with a `$t`-escape so a real dict containing a `"$t"` key is never mistaken for a tagged value. The walker traverses `starlark.Value` **directly** (never via `Unmarshal`, which would collapse type info); output is **deterministic** (sorted object keys, sets ordered by encoded form); cycles use a visited set and **error rather than recurse**. `loads` returns fresh **unfrozen** values, matching `json.decode`. **Zero new dependencies** (stdlib `encoding/json` + `reflect`).

## Peripheral ring + verification

`config.go` registration + **CapPure** capability, `module_test.go` list, repo README table + `Modules:` line, and `lib/serial/README.md` are all updated. Tests are a single source-shaped `serial_test.go` (no per-fix file, no third-party test framework): round-trips for every type, type preservation (tuple stays tuple, bytes stays bytes…), determinism golden, `$t` escape, deep nesting, and every error boundary. **serial.go at 95.5%** (only defensive never-reached arms uncovered); `gofmt`/`vet` clean; `-race -count=2` and the **go1.19 floor (Docker)** green.

Refs: R3 / ADR-013; downstream consumer PKG-10 (cache).