### PR TITLE
[fix] regex: error on a group index that overflows int64 (LET-25)

### DIFF
--- a/lib/regex/regex.go
+++ b/lib/regex/regex.go
@@ -605,9 +605,14 @@ func (m *Match) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable type: 
 func (m *Match) groupIndex(v starlark.Value) (int, error) {
 	switch g := v.(type) {
 	case starlark.Int:
-		i, _ := g.Int64()
-		if i < 0 || int(i) > m.p.search.NumSubexp() {
-			return 0, fmt.Errorf("no such group: %d", i)
+		// Int64 reports ok=false when the index overflows int64; the
+		// discarded ok used to leave i==0, silently selecting group 0 (the
+		// whole match) for a huge index instead of erroring. Compare as
+		// int64 to avoid truncating on the way to int, and format the
+		// original value (an overflowing index prints as 0 via %d).
+		i, ok := g.Int64()
+		if !ok || i < 0 || i > int64(m.p.search.NumSubexp()) {
+			return 0, fmt.Errorf("no such group: %s", g.String())
 		}
 		return int(i), nil
 	case starlark.String:

--- a/lib/regex/regex_test.go
+++ b/lib/regex/regex_test.go
@@ -234,6 +234,21 @@ func TestLoadModule_Regex(t *testing.T) {
 			wantErr: `no such group: 5`,
 		},
 		{
+			// a group index too large for int64 used to be silently truncated
+			// to 0 (the whole match) instead of erroring; group/start/end/span
+			// all route through groupIndex and must reject it loudly.
+			name: `error: group index overflows int64`,
+			script: itn.HereDoc(`
+				load('regex', 'search')
+				m = search('(a)', 'a')
+				assert.eq(m.group(1), 'a')
+				assert.fails(lambda: m.group(1 << 70), 'no such group')
+				assert.fails(lambda: m.start(1 << 70), 'no such group')
+				assert.fails(lambda: m.end(1 << 70), 'no such group')
+				assert.fails(lambda: m.span(1 << 70), 'no such group')
+			`),
+		},
+		{
 			name: `error: bad repl type`,
 			script: itn.HereDoc(`
 				load('regex', 'sub')


### PR DESCRIPTION
## What

`Match.group` / `start` / `end` / `span` resolve their group selector through `groupIndex`, which called `starlark.Int.Int64()` and **discarded the `ok` flag**. For an index too large for int64, `Int64()` returns `0`, so the bounds check passed and the call silently selected **group 0** (the whole match) instead of erroring — `m.group(1 << 70)` returned the full match text.

## Fix

Capture `ok` and reject an overflowing (or out-of-range) index with `no such group`, comparing as `int64` to avoid truncation and formatting the original value (which prints as `0` via `%d`). `groupIndex` is the single chokepoint, so this fixes `group`/`start`/`end`/`span` together — matching CPython, which raises `IndexError: no such group`.

## Test-first

A new section in `regex_test.go` asserts `group`/`start`/`end`/`span` all fail with `no such group` on `1 << 70`; it passes for a normal index. Fails before the fix.

## Verification

`go test -race -count=2 ./...`, `go vet`, `gofmt -l` clean, Docker `golang:1.19` race run green.

Requirement: **LET-25**