### PR TITLE
[fix] json: validate a single JSON document, rejecting trailing content (LET-27)

### DIFF
--- a/lib/json/json_test.go
+++ b/lib/json/json_test.go
@@ -1028,6 +1028,33 @@ func TestJSONValidate(t *testing.T) {
 			`),
 		},
 		{
+			// only the first JSON document was validated; trailing content
+			// (a second document or garbage) silently passed, so a script
+			// believed the whole text conformed. The data must be a single
+			// JSON document.
+			name: `validate: trailing content after the data document is rejected`,
+			script: itn.HereDoc(`
+				load('json', 'validate')
+				validate('{"a":1} {"b":2}', '{"type":"object"}')
+			`),
+			wantErr: `trailing content`,
+		},
+		{
+			name: `try_validate: a trailing document cannot sneak past as cannot-run`,
+			script: itn.HereDoc(`
+				load('json', 'try_validate')
+				# the trailing "x" would fail {"type":"number"} but was never
+				# checked; now the whole input is rejected as cannot-run.
+				res, err = try_validate('5 "x"', '{"type":"number"}')
+				assert.eq(res, None)
+				assert.true('trailing content' in err)
+				# trailing whitespace is still fine
+				ok, e2 = try_validate('5\n', '{"type":"number"}')
+				assert.eq(ok, True)
+				assert.eq(e2, None)
+			`),
+		},
+		{
 			name: `validate: draft-7 schema via $schema`,
 			script: itn.HereDoc(`
 				load('json', 'validate')

--- a/lib/json/validate.go
+++ b/lib/json/validate.go
@@ -136,6 +136,13 @@ func prepareValidation(data, schema starlark.Value) (*jsonschema.Schema, interfa
 	if err := dec.Decode(&doc); err != nil {
 		return nil, nil, fmt.Errorf("invalid data: %w", err)
 	}
+	// Validate a single JSON document. Trailing content (a second document
+	// or garbage) means the whole input was never checked, so reject it
+	// rather than silently validating only the first value. dec.More()
+	// stays false for trailing whitespace.
+	if dec.More() {
+		return nil, nil, fmt.Errorf("invalid data: unexpected trailing content after JSON document")
+	}
 	return compiled, doc, nil
 }
 


### PR DESCRIPTION
## What

`prepareValidation` decoded the `data` text with a `json.Decoder` and called `Decode` **once**, with no check that the input was exhausted. `encoding/json` reads only the first JSON value and discards the rest, so trailing content passed validation silently:

```
try_validate('{"a":1} {"b":2}', {'type':'object'}) -> (True, None)
try_validate('5 "x"', {'type':'number'})           -> (True, None)
```

In the second case the trailing `"x"` would fail `{'type':'number'}` but was never checked — a **validation bypass**. A caller believed the whole text conformed when only the first document did.

## Fix

Require EOF after the first document (`dec.More()`; trailing whitespace still passes). Trailing content routes through the cannot-run path, so `try_validate` returns `(None, error)` — not `(False, …)`.

## Test-first

New sections in `json_test.go` cover both `validate` (raises) and `try_validate` (returns cannot-run), including that pure trailing whitespace still passes. Fails before the fix.

## Verification

`go test -race -count=2 ./...`, `go vet`, `gofmt -l` clean, Docker `golang:1.19` race run green.

Requirement: **LET-27**