### PR TITLE
[doc] fix jsonrepair upstream link; clarify capability bits (LET-29)

### DIFF
--- a/config.go
+++ b/config.go
@@ -112,6 +112,13 @@ func DisableGlobalReassign() {
 // touch on the host. Policy layers use it to derive module sets instead of
 // maintaining hand-written name lists that silently rot as modules are
 // added.
+//
+// The bits model host *effects* (filesystem, network, process, log) only.
+// They deliberately say nothing about determinism or reproducibility: e.g.
+// random is CapPure (it has no host side effects) yet is non-deterministic
+// by design. A consumer that needs a "replayable / pure-function" set must
+// define it on its own side (excluding entropy/clock sources such as random
+// and time) rather than reading it off these capability bits.
 type ModuleCapability uint
 
 const (

--- a/lib/json/README.md
+++ b/lib/json/README.md
@@ -196,7 +196,7 @@ print(ok, err)
 
 ## Notes & boundaries
 
-- **Engines.** `encode`/`decode`/`indent` are go.starlark.net's stdlib `json`; `dumps` uses starlet's internal marshaler (handles host structs/modules); `path`/`eval` use [ajson](https://github.com/spyzhov/ajson) JSONPath; `repair` uses a vendored, frozen [jsonrepair](https://github.com/RealAlexandreAI/json-repair) (golden-locked); `validate` uses [santhosh-tekuri/jsonschema](https://github.com/santhosh-tekuri/jsonschema).
+- **Engines.** `encode`/`decode`/`indent` are go.starlark.net's stdlib `json`; `dumps` uses starlet's internal marshaler (handles host structs/modules); `path`/`eval` use [ajson](https://github.com/spyzhov/ajson) JSONPath; `repair` uses a vendored, frozen [jsonrepair](https://github.com/kaptinlin/jsonrepair) (golden-locked); `validate` uses [santhosh-tekuri/jsonschema](https://github.com/santhosh-tekuri/jsonschema).
 - **Purity.** No file or network access. JSON Schema `$ref` to external resources is blocked by design.
 - **Number shaping.** `path`/`eval` return integral numbers as `int` and non-integral as `float`; JSON `null` becomes `None`.
 - **`repair` vs `validate`.** `repair` fixes *text* and is idempotent on valid input; `validate` never mutates — it only reports conformance.


### PR DESCRIPTION
## What

Two documentation corrections:

1. **jsonrepair upstream link.** `lib/json/README.md` pointed `repair`'s vendored jsonrepair at `RealAlexandreAI/json-repair`, but the actual vendored upstream is **`kaptinlin/jsonrepair` v0.2.2** — confirmed by `internal/jsonrepair/doc.go`, its `LICENSE` (`Copyright (c) 2024 KaptinLin`), `codecov.yml`, and `.codacy.yml`. Fix the link to match.

2. **Capability bits clarification.** The `ModuleCapability` doc now states the bits model host **effects** (filesystem/network/process/log) only, not determinism/reproducibility. `random` is `CapPure` (no host side effects) yet non-deterministic by design; a consumer needing a "replayable / pure-function" set should define it on its own side (excluding entropy/clock sources such as `random` and `time`) rather than reading it off these bits.

Doc-only; no behavior change.

Requirement: **LET-29**