### PR TITLE
[fix] bound the script-controlled allocations in file, random, and choices

### DIFF
--- a/lib/file/README.md
+++ b/lib/file/README.md
@@ -92,7 +92,7 @@ print(data['num'], data['bool'], data['arr'])
 # Output: 42 True [1, 2, 3]
 ```
 
-`head_lines(name, n)` and `tail_lines(name, n)` return at most `n` lines from the start or end of the file. `n` must be a positive integer, otherwise they error (`expected positive integer, got -7`); a missing file errors as `open no-such-file:`. `count_lines(name)` returns the line count (0 for an empty file).
+`head_lines(name, n)` and `tail_lines(name, n)` return at most `n` lines from the start or end of the file. `n` must be a positive integer, otherwise they error (`expected positive integer, got -7`), and a value beyond `int64` errors (`n is too large`); neither allocates ahead of the lines actually read, so an `n` far larger than the file simply returns every line. A missing file errors as `open no-such-file:`. `count_lines(name)` returns the line count (0 for an empty file).
 
 ```python
 load('file', 'head_lines', 'tail_lines', 'count_lines')

--- a/lib/file/file.go
+++ b/lib/file/file.go
@@ -15,6 +15,11 @@ import (
 // in starlark's load() function, eg: load('file', 'trim_bom')
 const ModuleName = "file"
 
+// maxInt is the largest value of the platform int (2^31-1 on 32-bit,
+// 2^63-1 on 64-bit); used to clamp a script-provided count before it is
+// narrowed from int64 to int.
+const maxInt = int64(^uint(0) >> 1)
+
 var (
 	once       sync.Once
 	fileModule starlark.StringDict
@@ -97,9 +102,21 @@ func readTopOrBottomLines(funcName string, workLoad func(name string, n int) ([]
 		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "name", &fp, "n", &n); err != nil {
 			return starlark.None, err
 		}
-		nInt, _ := n.Int64()
+		// a value that does not fit an int64 makes Int64() undefined; reject it
+		// by name rather than letting the zero it yields masquerade as "n <= 0"
+		nInt, ok := n.Int64()
+		if !ok {
+			return starlark.None, fmt.Errorf(`%s: n is too large: %s`, b.Name(), n.String())
+		}
 		if nInt <= 0 {
 			return starlark.None, fmt.Errorf(`%s: expected positive integer, got %d`, b.Name(), n)
+		}
+		// clamp to the platform int max before narrowing: on a 32-bit int a huge
+		// n would wrap to a small value and silently return the wrong count.
+		// The readers grow to the file's actual line count, so an oversized n
+		// just means "every line" — maxInt stands in for "unbounded".
+		if nInt > maxInt {
+			nInt = maxInt
 		}
 
 		// read lines

--- a/lib/file/file_test.go
+++ b/lib/file/file_test.go
@@ -678,6 +678,26 @@ func TestLoadModule_File(t *testing.T) {
 			`),
 		},
 		{
+			// n sized the ring buffer up front, so a huge n allocated a huge
+			// slice and OOM-killed the host before reading a line. The buffer
+			// now grows to the file's actual line count, so a huge n simply
+			// means "every line".
+			name: `read tail lines: huge n does not preallocate`,
+			script: itn.HereDoc(`
+				load('file', 'tail_lines')
+				l = tail_lines('testdata/line_mac.txt', 1000000000000)
+				assert.eq(l, ['Line 1', 'Line 2', 'Line 3'])
+			`),
+		},
+		{
+			name: `read tail lines: n beyond int64`,
+			script: itn.HereDoc(`
+				load('file', 'tail_lines')
+				l = tail_lines('testdata/line_mac.txt', 18446744073709551616)
+			`),
+			wantErr: `file.tail_lines: n is too large`,
+		},
+		{
 			name: `read head lines: invalid args`,
 			script: itn.HereDoc(`
 				load('file', 'head_lines')

--- a/lib/file/line.go
+++ b/lib/file/line.go
@@ -89,12 +89,22 @@ func extractIOBottomLines(rd io.Reader, n int) ([]string, error) {
 	if n <= 0 {
 		return nil, errors.New("n should be greater than 0")
 	}
+	// Grow the ring buffer to the lines actually read instead of allocating n
+	// entries up front: n comes from the script, so tail_lines(path, 10**12)
+	// asked for a 10**12-entry slice — an OOM fatal (not a recoverable panic)
+	// before a single line was read, however small the file. The buffer never
+	// exceeds the file's line count, and the ring semantics are unchanged
+	// (the first n lines land at their own index, later ones overwrite).
 	var (
-		result = make([]string, n, n)
+		result []string
 		cnt    int
 	)
 	if err := readIOByLine(rd, func(line string) error {
-		result[cnt%n] = line
+		if len(result) < n {
+			result = append(result, line)
+		} else {
+			result[cnt%n] = line
+		}
 		cnt++
 		return nil
 	}); err != nil {

--- a/lib/random/README.md
+++ b/lib/random/README.md
@@ -23,7 +23,7 @@ This module exposes no constants and no custom types — every member is a funct
 
 ### `randbytes(n=10) -> bytes`
 
-Returns a random byte string of length `n`. If `n` is non-positive or omitted, the default length `10` is used. Errors only if the underlying RNG read fails.
+Returns a random byte string of length `n`. If `n` is non-positive or omitted, the default length `10` is used. `n` is capped at **1 MiB (1048576)** — a larger value errors (`n is too large: … (max 1048576)`) rather than letting a script drive an unbounded allocation. Also errors if the underlying RNG read fails.
 
 ```python
 load("random", "randbytes")
@@ -34,7 +34,7 @@ print(len(b))
 
 ### `randstr(chars, n=10) -> str`
 
-Returns a random string of `n` characters, each drawn uniformly from the characters in `chars`. `chars` is split into Unicode runes, so multi-byte characters are selected as whole code points (length is measured in bytes, e.g. each Chinese character contributes 3). If `n` is non-positive or omitted, the default length `10` is used. Errors when `chars` is empty (`chars must not be empty`).
+Returns a random string of `n` characters, each drawn uniformly from the characters in `chars`. `chars` is split into Unicode runes, so multi-byte characters are selected as whole code points (length is measured in bytes, e.g. each Chinese character contributes 3). If `n` is non-positive or omitted, the default length `10` is used; `n` is capped at **1 MiB (1048576)** and a larger value errors (`n is too large`). Errors when `chars` is empty (`chars must not be empty`).
 
 ```python
 load("random", "randstr")
@@ -45,7 +45,7 @@ print(x)
 
 ### `randb32(n=10, sep=0) -> str`
 
-Returns a random base32 string of `n` characters using the standard RFC 4648 alphabet (`A-Z`, `2-7`). If `sep` is positive and smaller than the string length, a dash is inserted every `sep` characters (this adds separator characters to the total length). If `n` is non-positive or omitted, the default length `10` is used; if `sep` is non-positive or omitted, no separator is inserted.
+Returns a random base32 string of `n` characters using the standard RFC 4648 alphabet (`A-Z`, `2-7`). If `sep` is positive and smaller than the string length, a dash is inserted every `sep` characters (this adds separator characters to the total length). If `n` is non-positive or omitted, the default length `10` is used; `n` is capped at **1 MiB (1048576)** and a larger value errors (`n is too large`). If `sep` is non-positive or omitted, no separator is inserted.
 
 ```python
 load("random", "randb32")

--- a/lib/random/random.go
+++ b/lib/random/random.go
@@ -4,6 +4,7 @@ package random
 import (
 	"crypto/rand"
 	"errors"
+	"fmt"
 	"math"
 	"math/big"
 	"sort"
@@ -54,6 +55,30 @@ var (
 	defaultLenN = big.NewInt(10)
 )
 
+// maxRandLen caps the script-controlled length of randbytes/randstr/randb32.
+// The length went straight from the script into make(), and big.Int.Int64() is
+// undefined for a value that does not fit an int64, so a script could:
+//   - randbytes(2**40) — ask for ~1 TiB and OOM-kill the host (a runtime fatal
+//     the run/call recover cannot catch);
+//   - randbytes(2**63) — get a negative length and panic make();
+//   - randbytes(2**64) — wrap to zero and silently receive nothing.
+//
+// 1 MiB of randomness is orders of magnitude past any realistic token/key/id.
+const maxRandLen = 1 << 20
+
+// randLen validates a script-provided length before it reaches make(): it must
+// fit an int64 (so Int64() is defined) and stay within maxRandLen.
+func randLen(name string, n *big.Int) (int64, error) {
+	if !n.IsInt64() {
+		return 0, fmt.Errorf("%s: n is too large: %s (max %d)", name, n.String(), maxRandLen)
+	}
+	v := n.Int64()
+	if v > maxRandLen {
+		return 0, fmt.Errorf("%s: n is too large: %d (max %d)", name, v, maxRandLen)
+	}
+	return v, nil
+}
+
 // randbytes(n) returns a random byte string of length n.
 func randbytes(thread *starlark.Thread, bn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	// precondition checks
@@ -66,8 +91,12 @@ func randbytes(thread *starlark.Thread, bn *starlark.Builtin, args starlark.Tupl
 	if nInt.Sign() <= 0 {
 		nInt = defaultLenN
 	}
+	ln, err := randLen(bn.Name(), nInt)
+	if err != nil {
+		return nil, err
+	}
 	// get random bytes
-	buf := make([]byte, nInt.Int64())
+	buf := make([]byte, ln)
 	if _, err := rand.Read(buf); err != nil {
 		return nil, err
 	}
@@ -89,8 +118,12 @@ func randstr(thread *starlark.Thread, bn *starlark.Builtin, args starlark.Tuple,
 	if nInt.Sign() <= 0 {
 		nInt = defaultLenN
 	}
+	ln, err := randLen(bn.Name(), nInt)
+	if err != nil {
+		return nil, err
+	}
 	// get random strings
-	s, err := getRandStr(ab.GoString(), nInt.Int64())
+	s, err := getRandStr(ab.GoString(), ln)
 	if err != nil {
 		return nil, err
 	}
@@ -109,18 +142,27 @@ func randb32(thread *starlark.Thread, bn *starlark.Builtin, args starlark.Tuple,
 	if nInt.Sign() <= 0 {
 		nInt = defaultLenN
 	}
+	ln, err := randLen(bn.Name(), nInt)
+	if err != nil {
+		return nil, err
+	}
 	nSep := sep.BigInt()
-	if nSep.Sign() <= 0 {
+	if nSep.Sign() <= 0 || !nSep.IsInt64() {
+		// an out-of-int64 separator would make Int64() undefined; no separator
 		nSep = big.NewInt(0)
 	}
 	// get random strings
 	const ab = `ABCDEFGHIJKLMNOPQRSTUVWXYZ234567` // standard base32 encoding chars, as defined in RFC 4648.
-	s, err := getRandStr(ab, nInt.Int64())
+	s, err := getRandStr(ab, ln)
 	if err != nil {
 		return nil, err
 	}
-	// add separator
-	if n := int(nSep.Int64()); n > 0 && n < len(s) {
+	// add separator; compare as int64 before narrowing to int, so a separator
+	// past a 32-bit int (but under int64) does not wrap on 32-bit platforms.
+	// A separator >= len(s) means no separator anyway, and len(s) <= maxRandLen
+	// fits an int, so the int() below is safe.
+	if sep64 := nSep.Int64(); sep64 > 0 && sep64 < int64(len(s)) {
+		n := int(sep64)
 		// add separator every n chars
 		var buf []rune
 		for i, r := range s {
@@ -209,6 +251,12 @@ func choices(thread *starlark.Thread, bn *starlark.Builtin, args starlark.Tuple,
 		l := starlark.NewList([]starlark.Value{})
 		return l, nil
 	}
+	// k sizes the result slice, so cap it like the other length-driven funcs:
+	// choices([1], k=2**40) would otherwise request a multi-terabyte slice and
+	// OOM-kill the host before the step budget could interrupt it.
+	if numOfResult > maxRandLen {
+		return nil, fmt.Errorf("%s: k is too large: %d (max %d)", bn.Name(), numOfResult, maxRandLen)
+	}
 
 	// get or calculate cumulative weights
 	var (
@@ -219,12 +267,15 @@ func choices(thread *starlark.Thread, bn *starlark.Builtin, args starlark.Tuple,
 		if weights != nil {
 			return nil, errors.New("cannot specify both weights and cumulative weights")
 		}
+		// check the length against the (small) population before materializing
+		// a float per weight, so a mismatched huge weights list is rejected
+		// without first allocating a same-sized []float64
+		if cumWeights.Len() != n {
+			return nil, errors.New("the number of weights does not match the population")
+		}
 		cumulativeWeights, err = listToFloat64Slice(cumWeights)
 		if err != nil {
 			return nil, err
-		}
-		if len(cumulativeWeights) != n {
-			return nil, errors.New("the number of weights does not match the population")
 		}
 		lastWeight := cumulativeWeights[0]
 		for i := 1; i < n; i++ {
@@ -234,12 +285,12 @@ func choices(thread *starlark.Thread, bn *starlark.Builtin, args starlark.Tuple,
 			lastWeight = cumulativeWeights[i]
 		}
 	} else if weights != nil {
+		if weights.Len() != n {
+			return nil, errors.New("the number of weights does not match the population")
+		}
 		relativeWeights, err := listToFloat64Slice(weights)
 		if err != nil {
 			return nil, err
-		}
-		if len(relativeWeights) != n {
-			return nil, errors.New("the number of weights does not match the population")
 		}
 		cumulativeWeights = make([]float64, n)
 		sum := 0.0

--- a/lib/random/random_test.go
+++ b/lib/random/random_test.go
@@ -239,6 +239,15 @@ func TestLoadModule_Random(t *testing.T) {
 			`),
 		},
 		{
+			// k sizes the result slice; a huge k would OOM the host
+			name: "choices with k over the cap",
+			script: itn.HereDoc(`
+				load('random', 'choices')
+				a = choices([1, 2, 3], k=1099511627776)
+			`),
+			wantErr: `random.choices: k is too large`,
+		},
+		{
 			name: "choices weights has 0",
 			script: itn.HereDoc(`
 				load('random', 'choices')
@@ -413,6 +422,49 @@ func TestLoadModule_Random(t *testing.T) {
 				assert.eq(len(x), 10)
 				y = randbytes(0)
 				assert.eq(len(y), 10)
+			`),
+		},
+		// n went straight into make(): a huge-but-int64 n OOM-killed the host,
+		// and a value past int64 made Int64() undefined (negative -> make panic,
+		// wrapped -> silently empty). All three are now bounded errors.
+		{
+			name: "randbytes with n over the cap",
+			script: itn.HereDoc(`
+				load('random', 'randbytes')
+				x = randbytes(1099511627776)
+			`),
+			wantErr: `random.randbytes: n is too large`,
+		},
+		{
+			name: "randbytes with n beyond int64",
+			script: itn.HereDoc(`
+				load('random', 'randbytes')
+				x = randbytes(18446744073709551616)
+			`),
+			wantErr: `random.randbytes: n is too large`,
+		},
+		{
+			name: "randstr with n over the cap",
+			script: itn.HereDoc(`
+				load('random', 'randstr')
+				x = randstr('abc', 1099511627776)
+			`),
+			wantErr: `random.randstr: n is too large`,
+		},
+		{
+			name: "randb32 with n over the cap",
+			script: itn.HereDoc(`
+				load('random', 'randb32')
+				x = randb32(1099511627776)
+			`),
+			wantErr: `random.randb32: n is too large`,
+		},
+		{
+			name: "randbytes at the cap still works",
+			script: itn.HereDoc(`
+				load('random', 'randbytes')
+				x = randbytes(1048576)
+				assert.eq(len(x), 1048576)
 			`),
 		},
 		{


### PR DESCRIPTION
## What

Several places let a script size a `make()` directly, with no upper bound — an OOM is a runtime fatal, so the run/call recover cannot turn it into an error.

- **`file.tail_lines(name, n)`** allocated its ring buffer as `make([]string, n, n)` before reading a line, so `tail_lines(path, 10**12)` OOM-killed the host however small the file. `head_lines` grew incrementally and had no such flaw — the asymmetry was the bug. The ring now grows to the lines actually read, so a huge `n` just means "every line". The entry point stops swallowing an out-of-int64 `n` and clamps to the platform int max before narrowing (no 32-bit wrap).
- **`random.randbytes`/`randstr`/`randb32`** passed `n` straight to `make()` after only a `Sign() <= 0` check, and `big.Int.Int64()` is undefined past int64 (negative → `make` panics, wrapped → silently empty, in-range-but-huge → OOM). A shared `randLen()` rejects a value that does not fit an int64 and caps the length at **1 MiB**. `randb32`'s separator is compared as int64 before narrowing.
- **`random.choices(pop, k=…)`** sized `make([]starlark.Value, k)` from `k` with no bound; `k` is now capped the same way, and the `weights`/`cum_weights` length is checked against the population before materializing a `[]float64`.

### Behavior change
`randbytes`/`randstr`/`randb32`/`choices` error on a length/`k` over 1 MiB instead of attempting the allocation. READMEs state the new bounds.

## Tests
Over-cap and beyond-int64 cases for each function; a huge `tail_lines` returns every line; at-cap still works. Full `-race`/`vet`/`gofmt`/doc-coverage/Docker go1.19 clean.
