### PR TITLE
[fix] make Machine.String race-free without blocking, and lock Reset

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -57,10 +57,27 @@ type Machine struct {
 	predeclared starlark.StringDict
 }
 
+// String renders a snapshot of the machine's state. Every field it reads is
+// written by Run/Reset under the write lock, so an unlocked read races with
+// them (and the thread was nil-checked and then dereferenced separately, so a
+// concurrent Reset could null it between and panic the host).
+//
+// It uses TryRLock rather than RLock so it never blocks: a plain RLock would
+// deadlock when String is reached while the write lock is held — most sharply
+// when a host prints the machine from within its own print/callback while Run
+// holds the lock (fmt logging the machine is an easy way to hit this). When the
+// lock is unavailable another goroutine (or this one, reentrantly) holds the
+// write lock — a run, a reset, or any setter — so it reports the machine as
+// running instead of reading the fields under mutation.
 func (m *Machine) String() string {
+	if !m.mu.TryRLock() {
+		return "🌠Machine{running}"
+	}
+	defer m.mu.RUnlock()
+
 	steps := uint64(0)
-	if m.thread != nil {
-		steps = m.thread.Steps
+	if t := m.thread; t != nil {
+		steps = t.Steps
 	}
 	return fmt.Sprintf("🌠Machine{run:%d,step:%d,script:%q,len:%d,fs:%v}",
 		m.runTimes, steps, m.scriptName, len(m.scriptContent), m.scriptFS)

--- a/machine_test.go
+++ b/machine_test.go
@@ -5,11 +5,74 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/1set/starlet"
 	"go.starlark.net/starlark"
 )
+
+// TestMachine_StringIsRaceFree: String() read m.thread/runTimes/scriptName
+// with no lock while Run and Reset wrote them, so printing a Machine from one
+// goroutine while another ran or reset it was a data race — and the separate
+// nil-check-then-deref of m.thread let a concurrent Reset null it in between
+// and panic the host. Both String and Reset now take the mutex. This test only
+// bites under -race, which the repo's bar runs.
+func TestMachine_StringIsRaceFree(t *testing.T) {
+	m := starlet.NewDefault()
+	m.SetScript("main.star", []byte(`x = len([i for i in range(1000)])`), nil)
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 30; i++ {
+			_, _ = m.Run()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 30; i++ {
+			m.Reset()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			_ = m.String()
+		}
+	}()
+	wg.Wait()
+}
+
+// TestMachine_StringInCallbackDoesNotDeadlock: Run holds the write lock for the
+// whole execution, so String() reaching for the lock from inside a callback of
+// the same run (e.g. logging the machine in its print func) would self-deadlock
+// on the non-reentrant mutex. String() uses TryRLock, so it returns the running
+// snapshot instead of blocking.
+func TestMachine_StringInCallbackDoesNotDeadlock(t *testing.T) {
+	m := starlet.NewDefault()
+	var got string
+	m.SetPrintFunc(func(_ *starlark.Thread, msg string) {
+		got = m.String() // reentrant: Run holds the lock here
+	})
+	m.SetScript("main.star", []byte(`print("x")`), nil)
+
+	done := make(chan error, 1)
+	go func() { _, err := m.Run(); done <- err }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run deadlocked: String() blocked on the write lock held by Run")
+	}
+	if got != "🌠Machine{running}" {
+		t.Fatalf("expected the running snapshot from the reentrant String(), got %q", got)
+	}
+}
 
 func TestNewDefault(t *testing.T) {
 	m := starlet.NewDefault()

--- a/run.go
+++ b/run.go
@@ -329,7 +329,14 @@ func (m *Machine) applyStepBudget() {
 
 // Reset resets the machine to initial state before the first run.
 // Attention: It does not reset the compiled program cache.
+//
+// It takes the write lock like the other mutators: it clears the very fields
+// (thread, runTimes, predeclared) that Run and the accessors read, so an
+// unlocked Reset would race with them however carefully the readers lock.
 func (m *Machine) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	m.runTimes = 0
 	m.thread = nil
 	m.loadCache = nil


### PR DESCRIPTION
## What

`Machine.String()` read `m.thread`, `m.runTimes`, `m.scriptName`, `m.scriptContent` with no lock while `Run` and `Reset` write exactly those fields. Every other accessor already takes the read lock, so this was an omission, not a trade-off: printing the machine from one goroutine while another runs it is a data race (`-race` reports it), and the separate nil-check-then-deref of `m.thread` let a concurrent `Reset` null it between and panic the host.

`String()` now guards the read with **`TryRLock`** rather than `RLock`, so it never blocks: `Run` holds the write lock for the whole execution, so a plain `RLock` would self-deadlock when `String` is reached from within a callback of that same run (`fmt`-logging the machine inside its own print func is an easy way to hit it). When the lock is unavailable a run/reset/setter is in flight, so `String` reports the machine as running rather than reading fields under mutation.

`Reset()` took no lock while clearing `thread`/`runTimes`/`predeclared` — the fields the readers read — so locking only the readers would not have removed the race. It now takes the write lock like the other mutators.

### Not addressed here (pre-existing follow-up)
`Machine.REPL()` writes `thread`/`predeclared` without the lock, so `String`/`Reset` still race with a running REPL; a locking strategy for an interactive session that does not block accessors is its own change.

## Tests
Run+Reset+String concurrently (the race detector reported 8 races before); `String` from the print callback returns the running snapshot instead of hanging. Full `-race`/`vet`/`gofmt`/Docker go1.19 clean.
