### PR TITLE
[chore] bump 1set/starlight to v0.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/1set/starlet
 go 1.19
 
 require (
-	github.com/1set/starlight v0.2.0
+	github.com/1set/starlight v0.2.1
 	github.com/google/uuid v1.6.0
 	github.com/h2so5/here v0.0.0-20200815043652-5e14eb691fae
 	github.com/montanaflynn/stats v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/1set/starlight v0.2.0 h1:W9yulJYANolyMLMOH0M4xcW8RQVpi68opSdNmoipcic=
-github.com/1set/starlight v0.2.0/go.mod h1:o9KiJBpy92daHyNHBUwS0nFIjjLxLM/XmRxAZf4FIaE=
+github.com/1set/starlight v0.2.1 h1:07XiRr4XJ9p8rSL/A4XDC7sDInGszpXIP5jASCIZo10=
+github.com/1set/starlight v0.2.1/go.mod h1:o9KiJBpy92daHyNHBUwS0nFIjjLxLM/XmRxAZf4FIaE=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=


### PR DESCRIPTION
Bumps the `1set/starlight` dependency from v0.2.0 to **v0.2.1** ("Firm Footing").

## Why

starlight v0.2.1 carries the deterministic compound map-key ordering fix (plus a stack-overflow guard for self-referential pointer keys) and the convert-completeness fixes (Slice struct tag, composite `tryConv` fallback, `GoInterface` deref). Pinning it here lets the whole downstream (starpkg modules, starcli) converge on **one** starlight version *through* starlet, instead of some repos pulling starlight v0.2.0 transitively while others pull v0.2.1 directly — the diamond-dependency waste we want to avoid before cutting the next starlet release.

## Scope

Dependency bump only (`go.mod` / `go.sum`). No starlet source change; no behavior change in starlet itself.

## Verification

`go build ./...`, `go test ./...`, `go test -race`, and `docker golang:1.19 go test ./...` all green. This is the dependency-convergence PR that precedes the starlet v0.2.3 tag.